### PR TITLE
Implement opt-in PII redaction in TypeScript SDK

### DIFF
--- a/examples/10-pii-redaction.ts
+++ b/examples/10-pii-redaction.ts
@@ -1,0 +1,76 @@
+/* eslint-disable no-console */
+
+// Minimal manual verification example for source-side PII redaction.
+//
+// Run with:
+//   npm run example:pii-redaction
+//
+// Expected markers in the printed payload:
+//   [REDACTED_EMAIL]
+//   [REDACTED_PHONE]
+//   [REDACTED_SECRET]
+
+import * as ze from 'zeroeval';
+
+ze.init({
+  apiKey: 'demo-api-key',
+  redaction: {
+    enabled: true,
+  },
+});
+
+async function main(): Promise<void> {
+  const sessionId = 'alice@example.com';
+
+  const span = ze.tracer.startSpan('demo.pii_redaction', {
+    sessionId,
+    sessionName: 'Alice Example <alice@example.com>',
+    tags: {
+      customer_email: 'alice@example.com',
+      auth_token: 'Bearer super-secret-token',
+    },
+    attributes: {
+      messages: [
+        {
+          role: 'user',
+          content:
+            'My email is alice@example.com and my phone is +1 (415) 555-1212',
+        },
+      ],
+      authorization: 'Bearer top-secret-token',
+    },
+  });
+
+  span.setIO(
+    {
+      email: 'alice@example.com',
+      phone: '+1 (415) 555-1212',
+      password: 'hunter2',
+      apiKey: 'sk-live-abcdef1234567890',
+    },
+    'Send follow-up to alice@example.com. Session cookie: abc123'
+  );
+
+  span.setError({
+    code: 'DEMO_ERROR',
+    message:
+      'Authorization: Bearer top-secret-token; contact alice@example.com for help',
+  });
+
+  ze.tracer.addSessionTags(sessionId, {
+    support_email: 'alice@example.com',
+  });
+
+  ze.tracer.endSpan(span);
+
+  console.log('Redacted span payload:\n');
+  console.log(JSON.stringify(span.toJSON(), null, 2));
+
+  // Exit without flushing so manual verification does not require backend access.
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/10-pii-redaction.ts
+++ b/examples/10-pii-redaction.ts
@@ -6,9 +6,10 @@
 //   npm run example:pii-redaction
 //
 // Expected markers in the printed payload:
-//   [REDACTED_EMAIL]
-//   [REDACTED_PHONE]
-//   [REDACTED_SECRET]
+//   [REDACTED_EMAIL_A]
+//   [REDACTED_EMAIL_B]
+//   [REDACTED_PHONE_A]
+//   [REDACTED_SECRET_A]
 
 import * as ze from 'zeroeval';
 
@@ -28,6 +29,7 @@ async function main(): Promise<void> {
     tags: {
       customer_email: 'alice@example.com',
       auth_token: 'Bearer super-secret-token',
+      backup_email: 'alice@example.com',
     },
     attributes: {
       messages: [
@@ -35,6 +37,11 @@ async function main(): Promise<void> {
           role: 'user',
           content:
             'My email is alice@example.com and my phone is +1 (415) 555-1212',
+        },
+        {
+          role: 'assistant',
+          content:
+            'Repeating alice@example.com with a second email bob@example.com',
         },
       ],
       authorization: 'Bearer top-secret-token',
@@ -47,8 +54,9 @@ async function main(): Promise<void> {
       phone: '+1 (415) 555-1212',
       password: 'hunter2',
       apiKey: 'sk-live-abcdef1234567890',
+      confirmEmail: 'alice@example.com',
     },
-    'Send follow-up to alice@example.com. Session cookie: abc123'
+    'Send follow-up to alice@example.com and bob@example.com. Session cookie: abc123'
   );
 
   span.setError({
@@ -59,6 +67,7 @@ async function main(): Promise<void> {
 
   ze.tracer.addSessionTags(sessionId, {
     support_email: 'alice@example.com',
+    escalation_email: 'bob@example.com',
   });
 
   ze.tracer.endSpan(span);

--- a/examples/10-pii-redaction.ts
+++ b/examples/10-pii-redaction.ts
@@ -14,7 +14,7 @@
 import * as ze from 'zeroeval';
 
 ze.init({
-  apiKey: 'demo-api-key',
+  apiKey: 'placeholder',
   redaction: {
     enabled: true,
   },
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
       email: 'alice@example.com',
       phone: '+1 (415) 555-1212',
       password: 'hunter2',
-      apiKey: 'sk-live-abcdef1234567890',
+      apiKey: 'placeholder',
       confirmEmail: 'alice@example.com',
     },
     'Send follow-up to alice@example.com and bob@example.com. Session cookie: abc123'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeroeval",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeroeval",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "devDependencies": {
         "@ai-sdk/anthropic": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "example:signals": "npm run build && npx ts-node --esm examples/06-signals.ts",
     "example:ai-stream-consume": "npm run build && npx ts-node --esm examples/07-ai-stream-consume.ts",
     "example:prompt": "npm run build && npx ts-node --esm examples/08-prompt.ts",
-    "example:vapi": "npm run build && npx ts-node --esm examples/09-vapi.ts"
+    "example:vapi": "npm run build && npx ts-node --esm examples/09-vapi.ts",
+    "example:pii-redaction": "npm run build && npx ts-node --esm examples/10-pii-redaction.ts"
   },
   "peerDependencies": {
     "@ai-sdk/openai": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroeval",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "ZeroEval TypeScript SDK",
   "keywords": [
     "observability",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,10 @@ export function setTag(
 
   if (typeof target !== 'string') {
     // Span instance – just mutate in-place
-    Object.assign(target.tags, tracer.sanitizeTags(tags, target.traceId));
+    Object.assign(
+      target.tags,
+      tracer.sanitizeTags(tags, target.traceId, target.attributes)
+    );
   } else {
     // Heuristic: first check active trace ids
     if (tracer.isActiveTrace(target)) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,7 @@ export function setTag(
 
   if (typeof target !== 'string') {
     // Span instance – just mutate in-place
-    Object.assign(target.tags, tracer.sanitizeTags(tags));
+    Object.assign(target.tags, tracer.sanitizeTags(tags, target.traceId));
   } else {
     // Heuristic: first check active trace ids
     if (tracer.isActiveTrace(target)) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,7 @@ export function setTag(
 
   if (typeof target !== 'string') {
     // Span instance – just mutate in-place
-    Object.assign(target.tags, tags);
+    Object.assign(target.tags, tracer.sanitizeTags(tags));
   } else {
     // Heuristic: first check active trace ids
     if (tracer.isActiveTrace(target)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export { wrapOpenAI } from './observability/integrations/openaiWrapper';
 // Export wrapVercelAI for direct usage
 export { wrapVercelAI } from './observability/integrations/vercelAIWrapper';
 export { Span } from './observability/Span';
+export type { RedactionConfig } from './observability/redaction';
 
 // Integrations
 export { LangChainIntegration } from './observability/integrations/langchain';

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,6 +2,7 @@
 
 import { tracer } from './observability/Tracer';
 import { Logger, getLogger } from './observability/logger';
+import type { RedactionConfig } from './observability/redaction';
 
 const logger = getLogger('zeroeval');
 
@@ -14,6 +15,7 @@ export interface InitOptions {
   collectCodeDetails?: boolean;
   integrations?: Record<string, boolean>;
   debug?: boolean;
+  redaction?: Partial<RedactionConfig>;
 }
 
 // Track whether init has been called
@@ -56,6 +58,7 @@ export function init(opts: InitOptions = {}): void {
     collectCodeDetails,
     integrations,
     debug,
+    redaction,
   } = opts;
 
   // Check if debug mode is enabled via param or env var
@@ -100,6 +103,12 @@ export function init(opts: InitOptions = {}): void {
     maxSpans,
     collectCodeDetails,
     integrations,
+    redaction: {
+      ...redaction,
+      enabled:
+        redaction?.enabled ??
+        process.env.ZEROEVAL_REDACT_PII?.toLowerCase() === 'true',
+    },
   });
 
   // Mark as initialized

--- a/src/observability/Span.ts
+++ b/src/observability/Span.ts
@@ -1,5 +1,14 @@
 import { randomUUID } from 'crypto';
 import type { Signal } from './signals';
+import {
+  attachRedactionMetadata,
+  redactErrorInfo,
+  redactInputValue,
+  redactOutputValue,
+  resolveRedactionConfig,
+  safeSerialize,
+} from './redaction';
+import type { RedactionConfig, ResolvedRedactionConfig } from './redaction';
 
 export interface ErrorInfo {
   code?: string;
@@ -30,10 +39,16 @@ export class Span {
 
   error?: ErrorInfo;
   status: 'ok' | 'error' = 'ok';
+  private readonly redactionConfig: ResolvedRedactionConfig;
 
-  constructor(name: string, traceId?: string) {
+  constructor(
+    name: string,
+    traceId?: string,
+    redactionConfig?: Partial<RedactionConfig>
+  ) {
     this.name = name;
     this.traceId = traceId ?? randomUUID();
+    this.redactionConfig = resolveRedactionConfig(redactionConfig);
   }
 
   end(): void {
@@ -45,18 +60,28 @@ export class Span {
   }
 
   setError(info: ErrorInfo): void {
-    this.error = info;
+    const redacted = redactErrorInfo(info, this.redactionConfig);
+    this.error = redacted.value;
+    attachRedactionMetadata(this.attributes, redacted.metadata);
     this.status = 'error';
   }
 
   setIO(input?: unknown, output?: unknown): void {
     if (input !== undefined) {
+      const redacted = redactInputValue(input, this.redactionConfig);
       this.inputData =
-        typeof input === 'string' ? input : JSON.stringify(input);
+        typeof redacted.value === 'string'
+          ? redacted.value
+          : safeSerialize(redacted.value);
+      attachRedactionMetadata(this.attributes, redacted.metadata);
     }
     if (output !== undefined) {
+      const redacted = redactOutputValue(output, this.redactionConfig);
       this.outputData =
-        typeof output === 'string' ? output : JSON.stringify(output);
+        typeof redacted.value === 'string'
+          ? redacted.value
+          : safeSerialize(redacted.value);
+      attachRedactionMetadata(this.attributes, redacted.metadata);
     }
   }
 

--- a/src/observability/Span.ts
+++ b/src/observability/Span.ts
@@ -26,6 +26,7 @@ export class Span {
   endTime?: number;
 
   sessionId?: string;
+  sessionLookupId?: string;
   sessionName?: string;
 
   attributes: Record<string, unknown> = {};

--- a/src/observability/Span.ts
+++ b/src/observability/Span.ts
@@ -3,6 +3,7 @@ import type { Signal } from './signals';
 import {
   attachRedactionMetadata,
   createRedactionReferenceContext,
+  redactAttributes,
   redactErrorInfo,
   redactInputValue,
   redactOutputValue,
@@ -108,6 +109,18 @@ export class Span {
           : safeSerialize(redacted.value);
       attachRedactionMetadata(this.attributes, redacted.metadata);
     }
+  }
+
+  setAttributes(attrs: Record<string, unknown>): void {
+    const redacted = redactAttributes(
+      attrs,
+      this.redactionConfig,
+      this.redactionReferenceContext
+    );
+    if (redacted.value) {
+      Object.assign(this.attributes, redacted.value);
+    }
+    attachRedactionMetadata(this.attributes, redacted.metadata);
   }
 
   addSignal(

--- a/src/observability/Span.ts
+++ b/src/observability/Span.ts
@@ -2,13 +2,18 @@ import { randomUUID } from 'crypto';
 import type { Signal } from './signals';
 import {
   attachRedactionMetadata,
+  createRedactionReferenceContext,
   redactErrorInfo,
   redactInputValue,
   redactOutputValue,
   resolveRedactionConfig,
   safeSerialize,
 } from './redaction';
-import type { RedactionConfig, ResolvedRedactionConfig } from './redaction';
+import type {
+  RedactionConfig,
+  RedactionReferenceContext,
+  ResolvedRedactionConfig,
+} from './redaction';
 
 export interface ErrorInfo {
   code?: string;
@@ -41,15 +46,22 @@ export class Span {
   error?: ErrorInfo;
   status: 'ok' | 'error' = 'ok';
   private readonly redactionConfig: ResolvedRedactionConfig;
+  private readonly redactionReferenceContext?: RedactionReferenceContext;
 
   constructor(
     name: string,
     traceId?: string,
-    redactionConfig?: Partial<RedactionConfig>
+    redactionConfig?: Partial<RedactionConfig>,
+    redactionReferenceContext?: RedactionReferenceContext
   ) {
     this.name = name;
     this.traceId = traceId ?? randomUUID();
     this.redactionConfig = resolveRedactionConfig(redactionConfig);
+    this.redactionReferenceContext =
+      redactionReferenceContext ??
+      (this.redactionConfig.enabled
+        ? createRedactionReferenceContext()
+        : undefined);
   }
 
   end(): void {
@@ -61,7 +73,11 @@ export class Span {
   }
 
   setError(info: ErrorInfo): void {
-    const redacted = redactErrorInfo(info, this.redactionConfig);
+    const redacted = redactErrorInfo(
+      info,
+      this.redactionConfig,
+      this.redactionReferenceContext
+    );
     this.error = redacted.value;
     attachRedactionMetadata(this.attributes, redacted.metadata);
     this.status = 'error';
@@ -69,7 +85,11 @@ export class Span {
 
   setIO(input?: unknown, output?: unknown): void {
     if (input !== undefined) {
-      const redacted = redactInputValue(input, this.redactionConfig);
+      const redacted = redactInputValue(
+        input,
+        this.redactionConfig,
+        this.redactionReferenceContext
+      );
       this.inputData =
         typeof redacted.value === 'string'
           ? redacted.value
@@ -77,7 +97,11 @@ export class Span {
       attachRedactionMetadata(this.attributes, redacted.metadata);
     }
     if (output !== undefined) {
-      const redacted = redactOutputValue(output, this.redactionConfig);
+      const redacted = redactOutputValue(
+        output,
+        this.redactionConfig,
+        this.redactionReferenceContext
+      );
       this.outputData =
         typeof redacted.value === 'string'
           ? redacted.value
@@ -115,6 +139,10 @@ export class Span {
       value,
       type: signalType,
     };
+  }
+
+  getRedactionReferenceContext(): RedactionReferenceContext | undefined {
+    return this.redactionReferenceContext;
   }
 
   toJSON(): Record<string, unknown> {

--- a/src/observability/Span.ts
+++ b/src/observability/Span.ts
@@ -32,7 +32,8 @@ export class Span {
   endTime?: number;
 
   sessionId?: string;
-  sessionLookupId?: string;
+  /** @internal Raw session identifier for internal lookup; not included in toJSON(). */
+  _sessionLookupId?: string;
   sessionName?: string;
 
   attributes: Record<string, unknown> = {};

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -20,6 +20,7 @@ import {
 } from './redaction';
 import type {
   RedactionConfig,
+  RedactionMetadata,
   RedactionReferenceContext,
   ResolvedRedactionConfig,
 } from './redaction';
@@ -30,6 +31,27 @@ if (process.env.ZEROEVAL_DEBUG?.toLowerCase() === 'true') {
 }
 
 const logger = getLogger('zeroeval.tracer');
+
+function mergeRedactionMetadata(
+  existing?: RedactionMetadata,
+  next?: RedactionMetadata
+): RedactionMetadata | undefined {
+  if (!next) {
+    return existing;
+  }
+  if (!existing) {
+    return {
+      enabled: true,
+      count: next.count,
+      types: [...next.types],
+    };
+  }
+  return {
+    enabled: true,
+    count: existing.count + next.count,
+    types: Array.from(new Set([...existing.types, ...next.types])),
+  };
+}
 
 interface ConfigureOptions {
   flushInterval?: number;
@@ -52,7 +74,10 @@ export class Tracer {
   private _activeTraceCounts: Record<string, number> = {};
   private _traceBuckets: Record<string, Span[]> = {};
   private _traceTags: Record<string, Record<string, string>> = {};
+  private _traceTagMetadata: Record<string, RedactionMetadata | undefined> = {};
   private _sessionTags: Record<string, Record<string, string>> = {};
+  private _sessionTagMetadata: Record<string, RedactionMetadata | undefined> =
+    {};
   private _activeSessionCounts: Record<string, number> = {};
   private _traceRedactionContexts: Record<string, RedactionReferenceContext> =
     {};
@@ -118,6 +143,32 @@ export class Tracer {
     return stack && stack[stack.length - 1];
   }
 
+  private applyTraceTagsToSpan(
+    span: Span,
+    tags?: Record<string, string>,
+    metadata?: RedactionMetadata
+  ): void {
+    if (!tags) {
+      return;
+    }
+    Object.assign(span.traceTags, tags);
+    Object.assign(span.tags, tags);
+    attachRedactionMetadata(span.attributes, metadata);
+  }
+
+  private applySessionTagsToSpan(
+    span: Span,
+    tags?: Record<string, string>,
+    metadata?: RedactionMetadata
+  ): void {
+    if (!tags) {
+      return;
+    }
+    Object.assign(span.sessionTags, tags);
+    Object.assign(span.tags, tags);
+    attachRedactionMetadata(span.attributes, metadata);
+  }
+
   /* TRACING ---------------------------------------------------------------*/
   startSpan(
     name: string,
@@ -169,19 +220,31 @@ export class Tracer {
       this._redaction,
       referenceContext
     );
+    const sessionTagLookupId = parent?.sessionLookupId ?? opts.sessionId;
+    const inheritedTraceTags = {
+      ...(parent?.traceTags ?? {}),
+      ...(this._traceTags[spanTraceId] ?? {}),
+    };
+    const inheritedTraceTagMetadata = this._traceTagMetadata[spanTraceId];
+    const inheritedSessionTags = {
+      ...(parent?.sessionTags ?? {}),
+      ...((sessionTagLookupId && this._sessionTags[sessionTagLookupId]) ?? {}),
+    };
+    const inheritedSessionTagMetadata = sessionTagLookupId
+      ? this._sessionTagMetadata[sessionTagLookupId]
+      : undefined;
 
     if (parent) {
       span.parentId = parent.spanId;
       span.sessionId = parent.sessionId;
       span.sessionLookupId = parent.sessionLookupId;
       span.sessionName = parent.sessionName;
-      // inherit tags
+      span.traceTags = inheritedTraceTags;
+      span.sessionTags = inheritedSessionTags;
       span.tags = {
         ...parent.tags,
-        ...(this._traceTags[parent.traceId] ?? {}),
-        ...(parent.sessionLookupId
-          ? (this._sessionTags[parent.sessionLookupId] ?? {})
-          : {}),
+        ...span.traceTags,
+        ...span.sessionTags,
         ...(redactedTags.value ?? {}),
       };
       logger.debug(`Span ${name} inherits from parent ${parent.name}`);
@@ -190,11 +253,11 @@ export class Tracer {
       span.sessionLookupId = rawSessionId;
       span.sessionId = redactedSessionId.value ?? rawSessionId;
       span.sessionName = redactedSessionName.value;
+      span.traceTags = inheritedTraceTags;
+      span.sessionTags = inheritedSessionTags;
       span.tags = {
-        ...(this._traceTags[span.traceId] ?? {}),
-        ...(span.sessionLookupId
-          ? (this._sessionTags[span.sessionLookupId] ?? {})
-          : {}),
+        ...span.traceTags,
+        ...span.sessionTags,
         ...(redactedTags.value ?? {}),
       };
       logger.debug(
@@ -203,6 +266,8 @@ export class Tracer {
     }
 
     Object.assign(span.attributes, redactedAttributes.value);
+    attachRedactionMetadata(span.attributes, inheritedTraceTagMetadata);
+    attachRedactionMetadata(span.attributes, inheritedSessionTagMetadata);
     attachRedactionMetadata(span.attributes, redactedAttributes.metadata);
     attachRedactionMetadata(span.attributes, redactedTags.metadata);
     attachRedactionMetadata(span.attributes, redactedSessionName.metadata);
@@ -250,6 +315,7 @@ export class Tracer {
       const ordered = traceBucket.sort((a) => (a.parentId ? 1 : -1));
       delete this._traceBuckets[span.traceId];
       delete this._traceTags[span.traceId];
+      delete this._traceTagMetadata[span.traceId];
       this._buffer.push(...ordered);
 
       if (span.sessionLookupId) {
@@ -257,6 +323,7 @@ export class Tracer {
         if (this._activeSessionCounts[span.sessionLookupId] === 0) {
           delete this._activeSessionCounts[span.sessionLookupId];
           delete this._sessionTags[span.sessionLookupId];
+          delete this._sessionTagMetadata[span.sessionLookupId];
         }
       }
 
@@ -288,19 +355,34 @@ export class Tracer {
       ...(this._traceTags[traceId] ?? {}),
       ...(redactedTags.value ?? {}),
     };
+    this._traceTagMetadata[traceId] = mergeRedactionMetadata(
+      this._traceTagMetadata[traceId],
+      redactedTags.metadata
+    );
 
     // update buckets
-    for (const span of this._traceBuckets[traceId] ?? [])
-      Object.assign(span.tags, redactedTags.value);
+    for (const span of this._traceBuckets[traceId] ?? []) {
+      this.applyTraceTagsToSpan(
+        span,
+        redactedTags.value,
+        redactedTags.metadata
+      );
+    }
     for (const span of als.getStore() ?? []) {
       if (span.traceId === traceId) {
-        Object.assign(span.tags, redactedTags.value);
+        this.applyTraceTagsToSpan(
+          span,
+          redactedTags.value,
+          redactedTags.metadata
+        );
       }
     }
     // update buffer if spans already flushed there
     this._buffer
       .filter((s) => s.traceId === traceId)
-      .forEach((s) => Object.assign(s.tags, redactedTags.value));
+      .forEach((s) =>
+        this.applyTraceTagsToSpan(s, redactedTags.value, redactedTags.metadata)
+      );
   }
 
   addSessionTags(sessionId: string, tags: Record<string, string>): void {
@@ -317,14 +399,20 @@ export class Tracer {
         span.sessionLookupId === sessionId || span.sessionId === sessionId
     );
     const matchedSpan = matchedSpans[0];
+    if (matchedSpans.length === 0) {
+      const logSessionId =
+        redactSessionIdentifier(sessionId, this._redaction).value ??
+        '[session]';
+      logger.debug(
+        `Skipping session tags for ${logSessionId}; no active or buffered spans matched`
+      );
+      return;
+    }
     const sessionTagKeys = new Set<string>();
     for (const span of matchedSpans) {
       if (span.sessionLookupId) {
         sessionTagKeys.add(span.sessionLookupId);
       }
-    }
-    if (sessionTagKeys.size === 0) {
-      sessionTagKeys.add(sessionId);
     }
     const redactedTags = redactTags(
       tags,
@@ -345,10 +433,18 @@ export class Tracer {
         ...(this._sessionTags[sessionTagKey] ?? {}),
         ...(redactedTags.value ?? {}),
       };
+      this._sessionTagMetadata[sessionTagKey] = mergeRedactionMetadata(
+        this._sessionTagMetadata[sessionTagKey],
+        redactedTags.metadata
+      );
     }
 
     matchedSpans.forEach((span) =>
-      Object.assign(span.tags, redactedTags.value)
+      this.applySessionTagsToSpan(
+        span,
+        redactedTags.value,
+        redactedTags.metadata
+      )
     );
   }
 
@@ -366,15 +462,18 @@ export class Tracer {
 
   sanitizeTags(
     tags: Record<string, string>,
-    traceId?: string
+    traceId?: string,
+    attributes?: Record<string, unknown>
   ): Record<string, string> {
-    return (
-      redactTags(
-        tags,
-        this._redaction,
-        traceId ? this._traceRedactionContexts[traceId] : undefined
-      ).value ?? tags
+    const redacted = redactTags(
+      tags,
+      this._redaction,
+      traceId ? this._traceRedactionContexts[traceId] : undefined
     );
+    if (attributes) {
+      attachRedactionMetadata(attributes, redacted.metadata);
+    }
+    return redacted.value ?? tags;
   }
 
   /* FLUSH -----------------------------------------------------------------*/
@@ -397,6 +496,7 @@ export class Tracer {
         delete this._traceRedactionContexts[traceId];
         if (!(traceId in this._activeTraceCounts)) {
           delete this._traceTags[traceId];
+          delete this._traceTagMetadata[traceId];
         }
       }
 
@@ -406,6 +506,7 @@ export class Tracer {
       for (const sessionId of flushedSessionIds) {
         if (sessionId && !(sessionId in this._activeSessionCounts)) {
           delete this._sessionTags[sessionId];
+          delete this._sessionTagMetadata[sessionId];
         }
       }
 

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -53,6 +53,7 @@ export class Tracer {
 
   private _activeTraceCounts: Record<string, number> = {};
   private _traceBuckets: Record<string, Span[]> = {};
+  private _traceSessionLookupIds: Record<string, string | undefined> = {};
   private _traceTags: Record<string, Record<string, string>> = {};
   private _traceTagMetadata: Record<string, RedactionMetadata | undefined> = {};
   private _sessionTags: Record<string, Record<string, string>> = {};
@@ -263,6 +264,7 @@ export class Tracer {
       (this._activeTraceCounts[span.traceId] || 0) + 1;
 
     if (!parent && span.sessionLookupId) {
+      this._traceSessionLookupIds[span.traceId] = span.sessionLookupId;
       this._activeSessionCounts[span.sessionLookupId] =
         (this._activeSessionCounts[span.sessionLookupId] || 0) + 1;
     }
@@ -298,10 +300,13 @@ export class Tracer {
       this._buffer.push(...ordered);
       this._bufferedTraceIds.add(span.traceId);
 
-      if (span.sessionLookupId) {
-        this._activeSessionCounts[span.sessionLookupId] -= 1;
-        if (this._activeSessionCounts[span.sessionLookupId] === 0) {
-          delete this._activeSessionCounts[span.sessionLookupId];
+<<<<<<< HEAD
+      const traceSessionLookupId = this._traceSessionLookupIds[span.traceId];
+      delete this._traceSessionLookupIds[span.traceId];
+      if (traceSessionLookupId) {
+        this._activeSessionCounts[traceSessionLookupId] -= 1;
+        if (this._activeSessionCounts[traceSessionLookupId] === 0) {
+          delete this._activeSessionCounts[traceSessionLookupId];
         }
       }
 
@@ -489,6 +494,7 @@ export class Tracer {
 
       for (const traceId of flushedTraceIds) {
         delete this._traceRedactionContexts[traceId];
+        delete this._traceSessionLookupIds[traceId];
         if (!(traceId in this._activeTraceCounts)) {
           delete this._traceTags[traceId];
           delete this._traceTagMetadata[traceId];

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -373,6 +373,18 @@ export class Tracer {
 
       for (const traceId of flushedTraceIds) {
         delete this._traceRedactionContexts[traceId];
+        if (!(traceId in this._activeTraceCounts)) {
+          delete this._traceTags[traceId];
+        }
+      }
+
+      const flushedSessionIds = new Set(
+        spansToFlush.map((s) => s.sessionLookupId).filter(Boolean)
+      );
+      for (const sessionId of flushedSessionIds) {
+        if (sessionId && !(sessionId in this._activeSessionCounts)) {
+          delete this._sessionTags[sessionId];
+        }
       }
 
       logger.info(

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -300,7 +300,6 @@ export class Tracer {
       this._buffer.push(...ordered);
       this._bufferedTraceIds.add(span.traceId);
 
-<<<<<<< HEAD
       const traceSessionLookupId = this._traceSessionLookupIds[span.traceId];
       delete this._traceSessionLookupIds[span.traceId];
       if (traceSessionLookupId) {

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -9,6 +9,15 @@ import { setInterval } from 'timers';
 import { discoverIntegrations } from './integrations/utils';
 import type { Integration } from './integrations/base';
 import { getLogger, Logger } from './logger';
+import {
+  attachRedactionMetadata,
+  redactAttributes,
+  redactSessionIdentifier,
+  redactSessionName,
+  redactTags,
+  resolveRedactionConfig,
+} from './redaction';
+import type { RedactionConfig, ResolvedRedactionConfig } from './redaction';
 
 // Check for debug mode early
 if (process.env.ZEROEVAL_DEBUG?.toLowerCase() === 'true') {
@@ -22,6 +31,7 @@ interface ConfigureOptions {
   maxSpans?: number;
   collectCodeDetails?: boolean;
   integrations?: Record<string, boolean>;
+  redaction?: Partial<RedactionConfig>;
 }
 
 /** Global AsyncLocalStorage for span stacks */
@@ -36,9 +46,12 @@ export class Tracer {
 
   private _activeTraceCounts: Record<string, number> = {};
   private _traceBuckets: Record<string, Span[]> = {};
+  private _traceTags: Record<string, Record<string, string>> = {};
+  private _sessionTags: Record<string, Record<string, string>> = {};
 
   private _integrations: Record<string, Integration> = {};
   private _shuttingDown = false;
+  private _redaction: ResolvedRedactionConfig = resolveRedactionConfig();
 
   constructor() {
     logger.debug('Initializing tracer...');
@@ -82,6 +95,12 @@ export class Tracer {
       this._maxSpans = opts.maxSpans;
       logger.info(`Tracer max_spans configured to ${opts.maxSpans}.`);
     }
+    if (opts.redaction !== undefined) {
+      this._redaction = resolveRedactionConfig(opts.redaction);
+      if (this._writer instanceof BackendSpanWriter) {
+        this._writer.setRedactionConfig(this._redaction);
+      }
+    }
     logger.debug(`Tracer configuration updated:`, opts);
   }
 
@@ -101,28 +120,62 @@ export class Tracer {
       tags?: Record<string, string>;
     } = {}
   ): Span {
+    if (this._shuttingDown) {
+      const span = new Span(name, undefined, this._redaction);
+      span.end();
+      return span;
+    }
+
     logger.debug(`Starting span: ${name}`);
 
     const parent = this.currentSpan();
-    const span = new Span(name, parent?.traceId);
+    const span = new Span(name, parent?.traceId, this._redaction);
+    const redactedAttributes = redactAttributes(
+      opts.attributes,
+      this._redaction
+    );
+    const redactedTags = redactTags(opts.tags, this._redaction);
+    const redactedSessionName = redactSessionName(
+      opts.sessionName,
+      this._redaction
+    );
+    const redactedSessionId = redactSessionIdentifier(
+      opts.sessionId,
+      this._redaction
+    );
 
     if (parent) {
       span.parentId = parent.spanId;
       span.sessionId = parent.sessionId;
       span.sessionName = parent.sessionName;
       // inherit tags
-      span.tags = { ...parent.tags, ...opts.tags };
+      span.tags = {
+        ...parent.tags,
+        ...(this._traceTags[parent.traceId] ?? {}),
+        ...(parent.sessionId
+          ? (this._sessionTags[parent.sessionId] ?? {})
+          : {}),
+        ...(redactedTags.value ?? {}),
+      };
       logger.debug(`Span ${name} inherits from parent ${parent.name}`);
     } else {
-      span.sessionId = opts.sessionId ?? randomUUID();
-      span.sessionName = opts.sessionName;
-      span.tags = { ...opts.tags };
+      span.sessionId = redactedSessionId.value ?? randomUUID();
+      span.sessionName = redactedSessionName.value;
+      span.tags = {
+        ...(this._traceTags[span.traceId] ?? {}),
+        ...(span.sessionId ? (this._sessionTags[span.sessionId] ?? {}) : {}),
+        ...(redactedTags.value ?? {}),
+      };
       logger.debug(
         `Span ${name} is a root span with session ${span.sessionId}`
       );
     }
 
-    Object.assign(span.attributes, opts.attributes);
+    Object.assign(span.attributes, redactedAttributes.value);
+    attachRedactionMetadata(span.attributes, redactedAttributes.metadata);
+    attachRedactionMetadata(span.attributes, redactedTags.metadata);
+    attachRedactionMetadata(span.attributes, redactedSessionName.metadata);
+    attachRedactionMetadata(span.attributes, redactedSessionId.metadata);
 
     // push onto ALS stack
     const parentStack = als.getStore() ?? [];
@@ -176,28 +229,58 @@ export class Tracer {
 
   /* TAG HELPERS -----------------------------------------------------------*/
   addTraceTags(traceId: string, tags: Record<string, string>): void {
-    logger.debug(`Adding trace tags to ${traceId}:`, tags);
+    const redactedTags = redactTags(tags, this._redaction);
+    logger.debug(`Adding trace tags to ${traceId}:`, redactedTags.value);
+    this._traceTags[traceId] = {
+      ...(this._traceTags[traceId] ?? {}),
+      ...(redactedTags.value ?? {}),
+    };
 
     // update buckets
     for (const span of this._traceBuckets[traceId] ?? [])
-      Object.assign(span.tags, tags);
+      Object.assign(span.tags, redactedTags.value);
+    for (const span of als.getStore() ?? []) {
+      if (span.traceId === traceId) {
+        Object.assign(span.tags, redactedTags.value);
+      }
+    }
     // update buffer if spans already flushed there
     this._buffer
       .filter((s) => s.traceId === traceId)
-      .forEach((s) => Object.assign(s.tags, tags));
+      .forEach((s) => Object.assign(s.tags, redactedTags.value));
   }
 
   addSessionTags(sessionId: string, tags: Record<string, string>): void {
-    logger.debug(`Adding session tags to ${sessionId}:`, tags);
+    const redactedTags = redactTags(tags, this._redaction);
+    logger.debug(`Adding session tags to ${sessionId}:`, redactedTags.value);
+    this._sessionTags[sessionId] = {
+      ...(this._sessionTags[sessionId] ?? {}),
+      ...(redactedTags.value ?? {}),
+    };
 
     const all = [...Object.values(this._traceBuckets).flat(), ...this._buffer];
+    for (const span of als.getStore() ?? []) {
+      all.push(span);
+    }
     all
       .filter((s) => s.sessionId === sessionId)
-      .forEach((s) => Object.assign(s.tags, tags));
+      .forEach((s) => Object.assign(s.tags, redactedTags.value));
   }
 
   isActiveTrace(traceId: string): boolean {
-    return traceId in this._activeTraceCounts || traceId in this._traceBuckets;
+    return (
+      traceId in this._activeTraceCounts ||
+      traceId in this._traceBuckets ||
+      this._buffer.some((span) => span.traceId === traceId)
+    );
+  }
+
+  getRedactionConfig(): ResolvedRedactionConfig {
+    return this._redaction;
+  }
+
+  sanitizeTags(tags: Record<string, string>): Record<string, string> {
+    return redactTags(tags, this._redaction).value ?? tags;
   }
 
   /* FLUSH -----------------------------------------------------------------*/

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -302,8 +302,6 @@ export class Tracer {
         this._activeSessionCounts[span.sessionLookupId] -= 1;
         if (this._activeSessionCounts[span.sessionLookupId] === 0) {
           delete this._activeSessionCounts[span.sessionLookupId];
-          delete this._sessionTags[span.sessionLookupId];
-          delete this._sessionTagMetadata[span.sessionLookupId];
         }
       }
 

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -151,6 +151,14 @@ export class Tracer {
     attachRedactionMetadata(span.attributes, metadata);
   }
 
+  private hasMutableTraceState(traceId: string): boolean {
+    return (
+      traceId in this._activeTraceCounts ||
+      traceId in this._traceBuckets ||
+      this._buffer.some((span) => span.traceId === traceId)
+    );
+  }
+
   /* TRACING ---------------------------------------------------------------*/
   startSpan(
     name: string,
@@ -327,6 +335,13 @@ export class Tracer {
 
   /* TAG HELPERS -----------------------------------------------------------*/
   addTraceTags(traceId: string, tags: Record<string, string>): void {
+    if (!this.hasMutableTraceState(traceId)) {
+      logger.debug(
+        `Skipping trace tags for ${traceId}; no active or buffered spans matched`
+      );
+      return;
+    }
+
     const redactedTags = redactTags(
       tags,
       this._redaction,

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -61,6 +61,7 @@ export class Tracer {
   private _activeSessionCounts: Record<string, number> = {};
   private _traceRedactionContexts: Record<string, RedactionReferenceContext> =
     {};
+  private _bufferedTraceIds = new Set<string>();
 
   private _integrations: Record<string, Integration> = {};
   private _shuttingDown = false;
@@ -294,9 +295,8 @@ export class Tracer {
       delete this._activeTraceCounts[span.traceId];
       const ordered = traceBucket.sort((a) => (a.parentId ? 1 : -1));
       delete this._traceBuckets[span.traceId];
-      delete this._traceTags[span.traceId];
-      delete this._traceTagMetadata[span.traceId];
       this._buffer.push(...ordered);
+      this._bufferedTraceIds.add(span.traceId);
 
       if (span.sessionLookupId) {
         this._activeSessionCounts[span.sessionLookupId] -= 1;
@@ -450,7 +450,7 @@ export class Tracer {
     return (
       traceId in this._activeTraceCounts ||
       traceId in this._traceBuckets ||
-      this._buffer.some((span) => span.traceId === traceId)
+      this._bufferedTraceIds.has(traceId)
     );
   }
 
@@ -480,6 +480,9 @@ export class Tracer {
     this._lastFlush = Date.now();
     const spansToFlush = this._buffer.splice(0);
     const flushedTraceIds = new Set(spansToFlush.map((span) => span.traceId));
+    for (const traceId of flushedTraceIds) {
+      this._bufferedTraceIds.delete(traceId);
+    }
 
     try {
       const startTime = Date.now();
@@ -514,6 +517,9 @@ export class Tracer {
       );
       // Re-add the spans to the buffer for retry
       this._buffer.unshift(...spansToFlush);
+      for (const traceId of flushedTraceIds) {
+        this._bufferedTraceIds.add(traceId);
+      }
       throw error;
     }
   }

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -312,9 +312,20 @@ export class Tracer {
       matchingSpans.push(span);
     }
 
-    const matchedSpan = matchingSpans.find(
-      (span) => span.sessionLookupId === sessionId
+    const matchedSpans = matchingSpans.filter(
+      (span) =>
+        span.sessionLookupId === sessionId || span.sessionId === sessionId
     );
+    const matchedSpan = matchedSpans[0];
+    const sessionTagKeys = new Set<string>();
+    for (const span of matchedSpans) {
+      if (span.sessionLookupId) {
+        sessionTagKeys.add(span.sessionLookupId);
+      }
+    }
+    if (sessionTagKeys.size === 0) {
+      sessionTagKeys.add(sessionId);
+    }
     const redactedTags = redactTags(
       tags,
       this._redaction,
@@ -329,14 +340,16 @@ export class Tracer {
       ).value ??
       '[session]';
     logger.debug(`Adding session tags to ${logSessionId}:`, redactedTags.value);
-    this._sessionTags[sessionId] = {
-      ...(this._sessionTags[sessionId] ?? {}),
-      ...(redactedTags.value ?? {}),
-    };
+    for (const sessionTagKey of sessionTagKeys) {
+      this._sessionTags[sessionTagKey] = {
+        ...(this._sessionTags[sessionTagKey] ?? {}),
+        ...(redactedTags.value ?? {}),
+      };
+    }
 
-    matchingSpans
-      .filter((s) => s.sessionLookupId === sessionId)
-      .forEach((s) => Object.assign(s.tags, redactedTags.value));
+    matchedSpans.forEach((span) =>
+      Object.assign(span.tags, redactedTags.value)
+    );
   }
 
   isActiveTrace(traceId: string): boolean {

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -246,7 +246,6 @@ export class Tracer {
       const ordered = traceBucket.sort((a) => (a.parentId ? 1 : -1));
       delete this._traceBuckets[span.traceId];
       delete this._traceTags[span.traceId];
-      delete this._traceRedactionContexts[span.traceId];
       this._buffer.push(...ordered);
 
       if (span.sessionLookupId) {
@@ -361,11 +360,16 @@ export class Tracer {
 
     this._lastFlush = Date.now();
     const spansToFlush = this._buffer.splice(0);
+    const flushedTraceIds = new Set(spansToFlush.map((span) => span.traceId));
 
     try {
       const startTime = Date.now();
       await this._writer.write(spansToFlush);
       const duration = Date.now() - startTime;
+
+      for (const traceId of flushedTraceIds) {
+        delete this._traceRedactionContexts[traceId];
+      }
 
       logger.info(
         `[ZeroEval] Successfully flushed ${spanCount} spans in ${duration}ms`

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -12,6 +12,7 @@ import { getLogger, Logger } from './logger';
 import {
   attachRedactionMetadata,
   createRedactionReferenceContext,
+  mergeMetadata,
   redactAttributes,
   redactSessionIdentifier,
   redactSessionName,
@@ -31,27 +32,6 @@ if (process.env.ZEROEVAL_DEBUG?.toLowerCase() === 'true') {
 }
 
 const logger = getLogger('zeroeval.tracer');
-
-function mergeRedactionMetadata(
-  existing?: RedactionMetadata,
-  next?: RedactionMetadata
-): RedactionMetadata | undefined {
-  if (!next) {
-    return existing;
-  }
-  if (!existing) {
-    return {
-      enabled: true,
-      count: next.count,
-      types: [...next.types],
-    };
-  }
-  return {
-    enabled: true,
-    count: existing.count + next.count,
-    types: Array.from(new Set([...existing.types, ...next.types])),
-  };
-}
 
 interface ConfigureOptions {
   flushInterval?: number;
@@ -355,7 +335,7 @@ export class Tracer {
       ...(this._traceTags[traceId] ?? {}),
       ...(redactedTags.value ?? {}),
     };
-    this._traceTagMetadata[traceId] = mergeRedactionMetadata(
+    this._traceTagMetadata[traceId] = mergeMetadata(
       this._traceTagMetadata[traceId],
       redactedTags.metadata
     );
@@ -452,7 +432,7 @@ export class Tracer {
         ...(this._sessionTags[sessionTagKey] ?? {}),
         ...(redactedTags.value ?? {}),
       };
-      this._sessionTagMetadata[sessionTagKey] = mergeRedactionMetadata(
+      this._sessionTagMetadata[sessionTagKey] = mergeMetadata(
         this._sessionTagMetadata[sessionTagKey],
         redactedTags.metadata
       );

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -48,6 +48,7 @@ export class Tracer {
   private _traceBuckets: Record<string, Span[]> = {};
   private _traceTags: Record<string, Record<string, string>> = {};
   private _sessionTags: Record<string, Record<string, string>> = {};
+  private _activeSessionCounts: Record<string, number> = {};
 
   private _integrations: Record<string, Integration> = {};
   private _shuttingDown = false;
@@ -190,6 +191,11 @@ export class Tracer {
     this._activeTraceCounts[span.traceId] =
       (this._activeTraceCounts[span.traceId] || 0) + 1;
 
+    if (!parent && span.sessionLookupId) {
+      this._activeSessionCounts[span.sessionLookupId] =
+        (this._activeSessionCounts[span.sessionLookupId] || 0) + 1;
+    }
+
     return span;
   }
 
@@ -214,7 +220,16 @@ export class Tracer {
       delete this._activeTraceCounts[span.traceId];
       const ordered = traceBucket.sort((a) => (a.parentId ? 1 : -1));
       delete this._traceBuckets[span.traceId];
+      delete this._traceTags[span.traceId];
       this._buffer.push(...ordered);
+
+      if (span.sessionLookupId) {
+        this._activeSessionCounts[span.sessionLookupId] -= 1;
+        if (this._activeSessionCounts[span.sessionLookupId] === 0) {
+          delete this._activeSessionCounts[span.sessionLookupId];
+          delete this._sessionTags[span.sessionLookupId];
+        }
+      }
 
       logger.debug(
         `Trace ${span.traceId} complete with ${ordered.length} spans`

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -235,6 +235,10 @@ export class Tracer {
       stack.pop();
     }
 
+    if (!(span.traceId in this._activeTraceCounts)) {
+      return;
+    }
+
     // bucket by trace until root finished
     const traceBucket = (this._traceBuckets[span.traceId] ||= []);
     traceBucket.push(span);

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -454,10 +454,6 @@ export class Tracer {
     );
   }
 
-  getRedactionConfig(): ResolvedRedactionConfig {
-    return this._redaction;
-  }
-
   sanitizeTags(
     tags: Record<string, string>,
     traceId?: string,

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -482,9 +482,6 @@ export class Tracer {
     this._lastFlush = Date.now();
     const spansToFlush = this._buffer.splice(0);
     const flushedTraceIds = new Set(spansToFlush.map((span) => span.traceId));
-    for (const traceId of flushedTraceIds) {
-      this._bufferedTraceIds.delete(traceId);
-    }
 
     try {
       const startTime = Date.now();
@@ -492,6 +489,7 @@ export class Tracer {
       const duration = Date.now() - startTime;
 
       for (const traceId of flushedTraceIds) {
+        this._bufferedTraceIds.delete(traceId);
         delete this._traceRedactionContexts[traceId];
         delete this._traceSessionLookupIds[traceId];
         if (!(traceId in this._activeTraceCounts)) {
@@ -520,9 +518,6 @@ export class Tracer {
       );
       // Re-add the spans to the buffer for retry
       this._buffer.unshift(...spansToFlush);
-      for (const traceId of flushedTraceIds) {
-        this._bufferedTraceIds.add(traceId);
-      }
       throw error;
     }
   }

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -312,14 +312,23 @@ export class Tracer {
       matchingSpans.push(span);
     }
 
+    const matchedSpan = matchingSpans.find(
+      (span) => span.sessionLookupId === sessionId
+    );
     const redactedTags = redactTags(
       tags,
       this._redaction,
-      matchingSpans
-        .find((span) => span.sessionLookupId === sessionId)
-        ?.getRedactionReferenceContext()
+      matchedSpan?.getRedactionReferenceContext()
     );
-    logger.debug(`Adding session tags to ${sessionId}:`, redactedTags.value);
+    const logSessionId =
+      matchedSpan?.sessionId ??
+      redactSessionIdentifier(
+        sessionId,
+        this._redaction,
+        matchedSpan?.getRedactionReferenceContext()
+      ).value ??
+      '[session]';
+    logger.debug(`Adding session tags to ${logSessionId}:`, redactedTags.value);
     this._sessionTags[sessionId] = {
       ...(this._sessionTags[sessionId] ?? {}),
       ...(redactedTags.value ?? {}),
@@ -404,7 +413,7 @@ export class Tracer {
   private async _setupAvailableIntegrations(): Promise<void> {
     logger.info('Checking for available integrations...');
 
-    const available = await discoverIntegrations();
+    const available = (await discoverIntegrations()) ?? {};
 
     for (const [key, Ctor] of Object.entries(available)) {
       try {

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -11,13 +11,18 @@ import type { Integration } from './integrations/base';
 import { getLogger, Logger } from './logger';
 import {
   attachRedactionMetadata,
+  createRedactionReferenceContext,
   redactAttributes,
   redactSessionIdentifier,
   redactSessionName,
   redactTags,
   resolveRedactionConfig,
 } from './redaction';
-import type { RedactionConfig, ResolvedRedactionConfig } from './redaction';
+import type {
+  RedactionConfig,
+  RedactionReferenceContext,
+  ResolvedRedactionConfig,
+} from './redaction';
 
 // Check for debug mode early
 if (process.env.ZEROEVAL_DEBUG?.toLowerCase() === 'true') {
@@ -49,6 +54,8 @@ export class Tracer {
   private _traceTags: Record<string, Record<string, string>> = {};
   private _sessionTags: Record<string, Record<string, string>> = {};
   private _activeSessionCounts: Record<string, number> = {};
+  private _traceRedactionContexts: Record<string, RedactionReferenceContext> =
+    {};
 
   private _integrations: Record<string, Integration> = {};
   private _shuttingDown = false;
@@ -122,7 +129,12 @@ export class Tracer {
     } = {}
   ): Span {
     if (this._shuttingDown) {
-      const span = new Span(name, undefined, this._redaction);
+      const span = new Span(
+        name,
+        undefined,
+        this._redaction,
+        createRedactionReferenceContext()
+      );
       span.end();
       return span;
     }
@@ -130,19 +142,32 @@ export class Tracer {
     logger.debug(`Starting span: ${name}`);
 
     const parent = this.currentSpan();
-    const span = new Span(name, parent?.traceId, this._redaction);
+    const spanTraceId = parent?.traceId ?? randomUUID();
+    const referenceContext =
+      parent?.getRedactionReferenceContext() ??
+      this._traceRedactionContexts[spanTraceId] ??
+      createRedactionReferenceContext();
+    this._traceRedactionContexts[spanTraceId] = referenceContext;
+    const span = new Span(name, spanTraceId, this._redaction, referenceContext);
     const redactedAttributes = redactAttributes(
       opts.attributes,
-      this._redaction
+      this._redaction,
+      referenceContext
     );
-    const redactedTags = redactTags(opts.tags, this._redaction);
+    const redactedTags = redactTags(
+      opts.tags,
+      this._redaction,
+      referenceContext
+    );
     const redactedSessionName = redactSessionName(
       opts.sessionName,
-      this._redaction
+      this._redaction,
+      referenceContext
     );
     const redactedSessionId = redactSessionIdentifier(
       opts.sessionId,
-      this._redaction
+      this._redaction,
+      referenceContext
     );
 
     if (parent) {
@@ -221,6 +246,7 @@ export class Tracer {
       const ordered = traceBucket.sort((a) => (a.parentId ? 1 : -1));
       delete this._traceBuckets[span.traceId];
       delete this._traceTags[span.traceId];
+      delete this._traceRedactionContexts[span.traceId];
       this._buffer.push(...ordered);
 
       if (span.sessionLookupId) {
@@ -249,7 +275,11 @@ export class Tracer {
 
   /* TAG HELPERS -----------------------------------------------------------*/
   addTraceTags(traceId: string, tags: Record<string, string>): void {
-    const redactedTags = redactTags(tags, this._redaction);
+    const redactedTags = redactTags(
+      tags,
+      this._redaction,
+      this._traceRedactionContexts[traceId]
+    );
     logger.debug(`Adding trace tags to ${traceId}:`, redactedTags.value);
     this._traceTags[traceId] = {
       ...(this._traceTags[traceId] ?? {}),
@@ -271,18 +301,28 @@ export class Tracer {
   }
 
   addSessionTags(sessionId: string, tags: Record<string, string>): void {
-    const redactedTags = redactTags(tags, this._redaction);
+    const matchingSpans = [
+      ...Object.values(this._traceBuckets).flat(),
+      ...this._buffer,
+    ];
+    for (const span of als.getStore() ?? []) {
+      matchingSpans.push(span);
+    }
+
+    const redactedTags = redactTags(
+      tags,
+      this._redaction,
+      matchingSpans
+        .find((span) => span.sessionLookupId === sessionId)
+        ?.getRedactionReferenceContext()
+    );
     logger.debug(`Adding session tags to ${sessionId}:`, redactedTags.value);
     this._sessionTags[sessionId] = {
       ...(this._sessionTags[sessionId] ?? {}),
       ...(redactedTags.value ?? {}),
     };
 
-    const all = [...Object.values(this._traceBuckets).flat(), ...this._buffer];
-    for (const span of als.getStore() ?? []) {
-      all.push(span);
-    }
-    all
+    matchingSpans
       .filter((s) => s.sessionLookupId === sessionId)
       .forEach((s) => Object.assign(s.tags, redactedTags.value));
   }
@@ -299,8 +339,17 @@ export class Tracer {
     return this._redaction;
   }
 
-  sanitizeTags(tags: Record<string, string>): Record<string, string> {
-    return redactTags(tags, this._redaction).value ?? tags;
+  sanitizeTags(
+    tags: Record<string, string>,
+    traceId?: string
+  ): Record<string, string> {
+    return (
+      redactTags(
+        tags,
+        this._redaction,
+        traceId ? this._traceRedactionContexts[traceId] : undefined
+      ).value ?? tags
+    );
   }
 
   /* FLUSH -----------------------------------------------------------------*/

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -394,20 +394,47 @@ export class Tracer {
       matchingSpans.push(span);
     }
 
-    const matchedSpans = matchingSpans.filter(
-      (span) =>
-        span.sessionLookupId === sessionId || span.sessionId === sessionId
+    const rawMatchedSpans = matchingSpans.filter(
+      (span) => span.sessionLookupId === sessionId
     );
-    const matchedSpan = matchedSpans[0];
-    if (matchedSpans.length === 0) {
-      const logSessionId =
-        redactSessionIdentifier(sessionId, this._redaction).value ??
-        '[session]';
+    const publicMatchedSpans =
+      rawMatchedSpans.length > 0
+        ? rawMatchedSpans
+        : matchingSpans.filter((span) => span.sessionId === sessionId);
+    const matchedSpan = publicMatchedSpans[0];
+    const logSessionId =
+      matchedSpan?.sessionId ??
+      redactSessionIdentifier(
+        sessionId,
+        this._redaction,
+        matchedSpan?.getRedactionReferenceContext()
+      ).value ??
+      '[session]';
+
+    if (publicMatchedSpans.length === 0) {
       logger.debug(
         `Skipping session tags for ${logSessionId}; no active or buffered spans matched`
       );
       return;
     }
+
+    let matchedSpans = publicMatchedSpans;
+    if (rawMatchedSpans.length === 0) {
+      const matchedTraceIds = new Set(matchedSpans.map((span) => span.traceId));
+      const matchedSessionLookupIds = new Set(
+        matchedSpans
+          .map((span) => span.sessionLookupId)
+          .filter((value): value is string => Boolean(value))
+      );
+
+      if (matchedTraceIds.size !== 1 || matchedSessionLookupIds.size !== 1) {
+        logger.debug(
+          `Skipping session tags for ${logSessionId}; public session identifier matched multiple traces or session buckets`
+        );
+        return;
+      }
+    }
+
     const sessionTagKeys = new Set<string>();
     for (const span of matchedSpans) {
       if (span.sessionLookupId) {
@@ -419,14 +446,6 @@ export class Tracer {
       this._redaction,
       matchedSpan?.getRedactionReferenceContext()
     );
-    const logSessionId =
-      matchedSpan?.sessionId ??
-      redactSessionIdentifier(
-        sessionId,
-        this._redaction,
-        matchedSpan?.getRedactionReferenceContext()
-      ).value ??
-      '[session]';
     logger.debug(`Adding session tags to ${logSessionId}:`, redactedTags.value);
     for (const sessionTagKey of sessionTagKeys) {
       this._sessionTags[sessionTagKey] = {

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -400,14 +400,13 @@ export class Tracer {
 
     let matchedSpans = publicMatchedSpans;
     if (rawMatchedSpans.length === 0) {
-      const matchedTraceIds = new Set(matchedSpans.map((span) => span.traceId));
       const matchedSessionLookupIds = new Set(
         matchedSpans
           .map((span) => span.sessionLookupId)
           .filter((value): value is string => Boolean(value))
       );
 
-      if (matchedTraceIds.size !== 1 || matchedSessionLookupIds.size !== 1) {
+      if (matchedSessionLookupIds.size !== 1) {
         logger.debug(
           `Skipping session tags for ${logSessionId}; public session identifier matched multiple traces or session buckets`
         );

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -155,7 +155,7 @@ export class Tracer {
     return (
       traceId in this._activeTraceCounts ||
       traceId in this._traceBuckets ||
-      this._buffer.some((span) => span.traceId === traceId)
+      this._bufferedTraceIds.has(traceId)
     );
   }
 

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -210,7 +210,7 @@ export class Tracer {
       this._redaction,
       referenceContext
     );
-    const sessionTagLookupId = parent?.sessionLookupId ?? opts.sessionId;
+    const sessionTagLookupId = parent?._sessionLookupId ?? opts.sessionId;
     const inheritedTraceTags = {
       ...(parent?.traceTags ?? {}),
       ...(this._traceTags[spanTraceId] ?? {}),
@@ -227,7 +227,7 @@ export class Tracer {
     if (parent) {
       span.parentId = parent.spanId;
       span.sessionId = parent.sessionId;
-      span.sessionLookupId = parent.sessionLookupId;
+      span._sessionLookupId = parent._sessionLookupId;
       span.sessionName = parent.sessionName;
       span.traceTags = inheritedTraceTags;
       span.sessionTags = inheritedSessionTags;
@@ -240,7 +240,7 @@ export class Tracer {
       logger.debug(`Span ${name} inherits from parent ${parent.name}`);
     } else {
       const rawSessionId = opts.sessionId ?? randomUUID();
-      span.sessionLookupId = rawSessionId;
+      span._sessionLookupId = rawSessionId;
       span.sessionId = redactedSessionId.value ?? rawSessionId;
       span.sessionName = redactedSessionName.value;
       span.traceTags = inheritedTraceTags;
@@ -271,10 +271,10 @@ export class Tracer {
     this._activeTraceCounts[span.traceId] =
       (this._activeTraceCounts[span.traceId] || 0) + 1;
 
-    if (!parent && span.sessionLookupId) {
-      this._traceSessionLookupIds[span.traceId] = span.sessionLookupId;
-      this._activeSessionCounts[span.sessionLookupId] =
-        (this._activeSessionCounts[span.sessionLookupId] || 0) + 1;
+    if (!parent && span._sessionLookupId) {
+      this._traceSessionLookupIds[span.traceId] = span._sessionLookupId;
+      this._activeSessionCounts[span._sessionLookupId] =
+        (this._activeSessionCounts[span._sessionLookupId] || 0) + 1;
     }
 
     return span;
@@ -392,7 +392,7 @@ export class Tracer {
     }
 
     const rawMatchedSpans = matchingSpans.filter(
-      (span) => span.sessionLookupId === sessionId
+      (span) => span._sessionLookupId === sessionId
     );
     const publicMatchedSpans =
       rawMatchedSpans.length > 0
@@ -419,7 +419,7 @@ export class Tracer {
     if (rawMatchedSpans.length === 0) {
       const matchedSessionLookupIds = new Set(
         matchedSpans
-          .map((span) => span.sessionLookupId)
+          .map((span) => span._sessionLookupId)
           .filter((value): value is string => Boolean(value))
       );
 
@@ -433,8 +433,8 @@ export class Tracer {
 
     const sessionTagKeys = new Set<string>();
     for (const span of matchedSpans) {
-      if (span.sessionLookupId) {
-        sessionTagKeys.add(span.sessionLookupId);
+      if (span._sessionLookupId) {
+        sessionTagKeys.add(span._sessionLookupId);
       }
     }
     const redactedTags = redactTags(
@@ -514,7 +514,7 @@ export class Tracer {
       }
 
       const flushedSessionIds = new Set(
-        spansToFlush.map((s) => s.sessionLookupId).filter(Boolean)
+        spansToFlush.map((s) => s._sessionLookupId).filter(Boolean)
       );
       for (const sessionId of flushedSessionIds) {
         if (sessionId && !(sessionId in this._activeSessionCounts)) {

--- a/src/observability/Tracer.ts
+++ b/src/observability/Tracer.ts
@@ -147,23 +147,28 @@ export class Tracer {
     if (parent) {
       span.parentId = parent.spanId;
       span.sessionId = parent.sessionId;
+      span.sessionLookupId = parent.sessionLookupId;
       span.sessionName = parent.sessionName;
       // inherit tags
       span.tags = {
         ...parent.tags,
         ...(this._traceTags[parent.traceId] ?? {}),
-        ...(parent.sessionId
-          ? (this._sessionTags[parent.sessionId] ?? {})
+        ...(parent.sessionLookupId
+          ? (this._sessionTags[parent.sessionLookupId] ?? {})
           : {}),
         ...(redactedTags.value ?? {}),
       };
       logger.debug(`Span ${name} inherits from parent ${parent.name}`);
     } else {
-      span.sessionId = redactedSessionId.value ?? randomUUID();
+      const rawSessionId = opts.sessionId ?? randomUUID();
+      span.sessionLookupId = rawSessionId;
+      span.sessionId = redactedSessionId.value ?? rawSessionId;
       span.sessionName = redactedSessionName.value;
       span.tags = {
         ...(this._traceTags[span.traceId] ?? {}),
-        ...(span.sessionId ? (this._sessionTags[span.sessionId] ?? {}) : {}),
+        ...(span.sessionLookupId
+          ? (this._sessionTags[span.sessionLookupId] ?? {})
+          : {}),
         ...(redactedTags.value ?? {}),
       };
       logger.debug(
@@ -263,7 +268,7 @@ export class Tracer {
       all.push(span);
     }
     all
-      .filter((s) => s.sessionId === sessionId)
+      .filter((s) => s.sessionLookupId === sessionId)
       .forEach((s) => Object.assign(s.tags, redactedTags.value));
   }
 

--- a/src/observability/integrations/langchain.ts
+++ b/src/observability/integrations/langchain.ts
@@ -77,7 +77,7 @@ export class LangChainIntegration extends Integration {
               });
               try {
                 const res = await orig.apply(this, args);
-                span.setIO(JSON.stringify(args[0]), JSON.stringify(res));
+                span.setIO(args[0], res);
                 tracer.endSpan(span);
                 return res;
               } catch (err: any) {
@@ -116,7 +116,7 @@ export class LangChainIntegration extends Integration {
               if (res?.then) {
                 return res
                   .then((r: any) => {
-                    span.setIO(JSON.stringify(args[0]), JSON.stringify(r));
+                    span.setIO(args[0], r);
                     tracer.endSpan(span);
                     return r;
                   })
@@ -130,7 +130,7 @@ export class LangChainIntegration extends Integration {
                     throw err;
                   });
               }
-              span.setIO(JSON.stringify(args[0]), JSON.stringify(res));
+              span.setIO(args[0], res);
               tracer.endSpan(span);
               return res;
             } catch (err: any) {

--- a/src/observability/integrations/langchain/ZeroEvalCallbackHandler.ts
+++ b/src/observability/integrations/langchain/ZeroEvalCallbackHandler.ts
@@ -250,7 +250,7 @@ export class ZeroEvalCallbackHandler
         }
       }
 
-      Object.assign(span.attributes, additionalAttrs);
+      span.setAttributes(additionalAttrs);
       this.metadataPool.release(additionalAttrs);
     }
 

--- a/src/observability/integrations/langchain/ZeroEvalCallbackHandler.ts
+++ b/src/observability/integrations/langchain/ZeroEvalCallbackHandler.ts
@@ -50,25 +50,6 @@ class ObjectPool<T> {
   }
 }
 
-class LazySerializer {
-  private value: unknown;
-  private serialized?: string;
-
-  constructor(value: unknown) {
-    this.value = value;
-  }
-
-  toString(): string {
-    if (!this.serialized) {
-      this.serialized =
-        typeof this.value === 'string'
-          ? this.value
-          : JSON.stringify(this.value);
-    }
-    return this.serialized;
-  }
-}
-
 export class ZeroEvalCallbackHandler
   extends BaseCallbackHandler
   implements BaseCallbackHandlerInput
@@ -214,8 +195,7 @@ export class ZeroEvalCallbackHandler
     });
 
     if (input !== undefined) {
-      const lazyInput = new LazySerializer(input);
-      span.setIO(lazyInput.toString(), undefined);
+      span.setIO(input, undefined);
     }
 
     this.spans.set(runId, span);
@@ -251,8 +231,7 @@ export class ZeroEvalCallbackHandler
     }
 
     if (output !== undefined) {
-      const lazyOutput = new LazySerializer(output);
-      span.setIO(span.inputData, lazyOutput.toString());
+      span.setIO(span.inputData, output);
     }
 
     if (error) {

--- a/src/observability/integrations/langchain/ZeroEvalCallbackHandler.ts
+++ b/src/observability/integrations/langchain/ZeroEvalCallbackHandler.ts
@@ -231,7 +231,7 @@ export class ZeroEvalCallbackHandler
     }
 
     if (output !== undefined) {
-      span.setIO(span.inputData, output);
+      span.setIO(undefined, output);
     }
 
     if (error) {

--- a/src/observability/integrations/langgraph.ts
+++ b/src/observability/integrations/langgraph.ts
@@ -41,7 +41,7 @@ export class LangGraphIntegration extends Integration {
               });
               try {
                 const res = await orig.apply(this, args);
-                span.setIO(JSON.stringify(args[0]), JSON.stringify(res));
+                span.setIO(args[0], res);
                 tracer.endSpan(span);
                 return res;
               } catch (err: any) {
@@ -66,7 +66,7 @@ export class LangGraphIntegration extends Integration {
               if (res?.then) {
                 return res
                   .then((r: any) => {
-                    span.setIO(JSON.stringify(args[0]), JSON.stringify(r));
+                    span.setIO(args[0], r);
                     tracer.endSpan(span);
                     return r;
                   })
@@ -80,7 +80,7 @@ export class LangGraphIntegration extends Integration {
                     throw err;
                   });
               }
-              span.setIO(JSON.stringify(args[0]), JSON.stringify(res));
+              span.setIO(args[0], res);
               tracer.endSpan(span);
               return res;
             } catch (err: any) {

--- a/src/observability/integrations/openaiWrapper.ts
+++ b/src/observability/integrations/openaiWrapper.ts
@@ -302,7 +302,7 @@ function wrapCompletionsCreate(originalMethod: Function): Function {
             : 0;
         span.attributes.throughput = throughput;
 
-        span.setIO(JSON.stringify(serializedMessages), output);
+        span.setIO(serializedMessages, output);
       }
 
       tracer.endSpan(span);
@@ -357,10 +357,10 @@ function wrapGenericMethod(
       } else if (result?.embedding) {
         output = `embedding[${result.embedding.length}]`;
       } else {
-        output = JSON.stringify(result);
+        output = result;
       }
 
-      span.setIO(JSON.stringify(params), output);
+      span.setIO(params, output);
       tracer.endSpan(span);
       return result;
     } catch (error: any) {
@@ -424,7 +424,7 @@ async function* wrapStream(
         : 0;
     span.attributes.throughput = throughput;
 
-    span.setIO(JSON.stringify(serializedMessages), fullResponse);
+    span.setIO(serializedMessages, fullResponse);
   } catch (error: any) {
     errorOccurred = true;
     span.setError({

--- a/src/observability/integrations/vercelAIWrapper.ts
+++ b/src/observability/integrations/vercelAIWrapper.ts
@@ -214,7 +214,7 @@ function wrapVercelAIFunction<T extends VercelAIFunction>(
         }
         // For generateObject
         else if ('object' in result) {
-          const output = result.object ?? {};
+          const output = result.object || {};
 
           if (result.usage) {
             span.attributes.inputTokens = result.usage.promptTokens;

--- a/src/observability/integrations/vercelAIWrapper.ts
+++ b/src/observability/integrations/vercelAIWrapper.ts
@@ -173,13 +173,13 @@ function wrapVercelAIFunction<T extends VercelAIFunction>(
 
     try {
       // Prepare input for tracing
-      let input: string;
+      let input: unknown;
       if (messages) {
-        input = JSON.stringify(messages);
+        input = messages;
       } else if (prompt) {
-        input = typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
+        input = prompt;
       } else {
-        input = JSON.stringify(modifiedOptions);
+        input = modifiedOptions;
       }
 
       const result = await fn(modifiedOptions);
@@ -214,7 +214,7 @@ function wrapVercelAIFunction<T extends VercelAIFunction>(
         }
         // For generateObject
         else if ('object' in result) {
-          const output = result.object ? JSON.stringify(result.object) : '{}';
+          const output = result.object ?? {};
 
           if (result.usage) {
             span.attributes.inputTokens = result.usage.promptTokens;
@@ -236,7 +236,7 @@ function wrapVercelAIFunction<T extends VercelAIFunction>(
         }
         // For other results
         else {
-          span.setIO(input, JSON.stringify(result));
+          span.setIO(input, result);
         }
       } else {
         // If result is not an object, convert to string
@@ -272,7 +272,7 @@ function wrapVercelAIFunction<T extends VercelAIFunction>(
 function wrapStreamingResult(
   result: any,
   span: any,
-  input: string,
+  input: unknown,
   startTime: number
 ): any {
   // Create a proxy to intercept stream access
@@ -380,7 +380,7 @@ function wrapStreamingResult(
 async function* wrapAsyncIterator(
   iterator: AsyncIterable<any>,
   span: any,
-  input: string,
+  input: unknown,
   startTime: number,
   streamType: 'text' | 'full'
 ): AsyncIterable<any> {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -174,14 +174,6 @@ export function redactOutputValue(
   return redactValue(value, config, createTraversalContext(referenceContext));
 }
 
-export function redactTextValue(
-  value: string,
-  config: ResolvedRedactionConfig,
-  referenceContext?: RedactionReferenceContext
-): RedactionResult<string> {
-  return redactStringValue(value, config, referenceContext);
-}
-
 export function redactInputTextValue(
   value: string,
   config: ResolvedRedactionConfig,

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -1,0 +1,798 @@
+export interface RedactionConfig {
+  enabled: boolean;
+  redactInputs?: boolean;
+  redactOutputs?: boolean;
+  redactAttributes?: boolean;
+  redactErrors?: boolean;
+  redactSessionNames?: boolean;
+  redactTagValues?: boolean;
+  sensitiveKeys?: string[];
+  customPatterns?: Array<RegExp | string>;
+}
+
+export interface ResolvedRedactionConfig {
+  enabled: boolean;
+  redactInputs: boolean;
+  redactOutputs: boolean;
+  redactAttributes: boolean;
+  redactErrors: boolean;
+  redactSessionNames: boolean;
+  redactTagValues: boolean;
+  sensitiveKeys: string[];
+  customPatterns: RegExp[];
+}
+
+export interface RedactionMetadata {
+  enabled: true;
+  count: number;
+  types: string[];
+}
+
+type RedactionResult<T> = {
+  value: T;
+  metadata?: RedactionMetadata;
+};
+
+type RedactionType = 'EMAIL' | 'PHONE' | 'SSN' | 'PAN' | 'SECRET' | 'IP';
+
+type StringRedactionOptions = {
+  stable?: boolean;
+};
+
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const SSN_REGEX = /\b\d{3}-\d{2}-\d{4}\b/g;
+const IPV4_REGEX =
+  /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b/g;
+const IPV6_REGEX =
+  /\b(?:(?:[A-F0-9]{1,4}:){1,7}[A-F0-9]{0,4}|(?:[A-F0-9]{1,4}:){1,7}:|::(?:[A-F0-9]{1,4}:){0,6}[A-F0-9]{0,4})\b/gi;
+const JWT_REGEX = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\b/g;
+const API_KEY_REGEX =
+  /\b(?:sk|pk|rk|ghp|gho|ghu|ghs|github_pat|xox[baprs]-|AIza|ya29|AKIA|ASIA)[A-Za-z0-9._-]{8,}\b/g;
+const BEARER_REGEX = /\bBearer\s+[A-Za-z0-9\-._~+/]+=*\b/gi;
+const AUTH_HEADER_REGEX =
+  /\b(authorization|proxy-authorization)\s*[:=]\s*[^\r\n]+/gi;
+const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*[:=]\s*[^\r\n]+/gi;
+const PHONE_REGEX = /(?:\+?\d[\d().\s-]{7,}\d)/g;
+const PAN_CANDIDATE_REGEX = /\b(?:\d[ -]?){13,19}\b/g;
+
+const DEFAULT_SENSITIVE_KEYS = [
+  'email',
+  'phone',
+  'mobile',
+  'telephone',
+  'ssn',
+  'social_security',
+  'national_id',
+  'tax_id',
+  'credit_card',
+  'card_number',
+  'pan',
+  'password',
+  'passwd',
+  'pwd',
+  'secret',
+  'token',
+  'api_key',
+  'apikey',
+  'access_token',
+  'refresh_token',
+  'authorization',
+  'cookie',
+  'set_cookie',
+  'session_name',
+  'client_secret',
+];
+
+const REDACTION_KEY = 'zeroeval_redaction';
+
+export function resolveRedactionConfig(
+  config?: Partial<RedactionConfig>
+): ResolvedRedactionConfig {
+  const enabled = config?.enabled ?? false;
+
+  return {
+    enabled,
+    redactInputs: enabled && (config?.redactInputs ?? true),
+    redactOutputs: enabled && (config?.redactOutputs ?? true),
+    redactAttributes: enabled && (config?.redactAttributes ?? true),
+    redactErrors: enabled && (config?.redactErrors ?? true),
+    redactSessionNames: enabled && (config?.redactSessionNames ?? true),
+    redactTagValues: enabled && (config?.redactTagValues ?? true),
+    sensitiveKeys: Array.from(
+      new Set(
+        [...DEFAULT_SENSITIVE_KEYS, ...(config?.sensitiveKeys ?? [])].map(
+          normalizeKey
+        )
+      )
+    ),
+    customPatterns: (config?.customPatterns ?? [])
+      .map(normalizeCustomPattern)
+      .filter((pattern): pattern is RegExp => pattern instanceof RegExp),
+  };
+}
+
+export function redactInputValue(
+  value: unknown,
+  config: ResolvedRedactionConfig
+): RedactionResult<unknown> {
+  if (!config.enabled || !config.redactInputs) {
+    return { value };
+  }
+
+  return redactValue(value, config);
+}
+
+export function redactOutputValue(
+  value: unknown,
+  config: ResolvedRedactionConfig
+): RedactionResult<unknown> {
+  if (!config.enabled || !config.redactOutputs) {
+    return { value };
+  }
+
+  return redactValue(value, config);
+}
+
+export function redactAttributes(
+  value: Record<string, unknown> | undefined,
+  config: ResolvedRedactionConfig
+): RedactionResult<Record<string, unknown> | undefined> {
+  if (!value || !config.enabled || !config.redactAttributes) {
+    return { value };
+  }
+
+  return redactObject(value, config);
+}
+
+export function redactTags(
+  value: Record<string, string> | undefined,
+  config: ResolvedRedactionConfig
+): RedactionResult<Record<string, string> | undefined> {
+  if (!value || !config.enabled || !config.redactTagValues) {
+    return { value };
+  }
+
+  let nextValue: Record<string, string> | undefined;
+  let metadata: RedactionMetadata | undefined;
+
+  for (const [key, rawValue] of Object.entries(value)) {
+    const redactedValue = isSensitiveKey(key, config)
+      ? createPlaceholderForValue(rawValue)
+      : redactString(rawValue, config).value;
+
+    if (!nextValue && redactedValue !== rawValue) {
+      nextValue = { ...value };
+    }
+
+    if (nextValue) {
+      nextValue[key] = redactedValue;
+    }
+
+    if (redactedValue !== rawValue) {
+      const type = detectRedactionType(rawValue);
+      metadata = mergeMetadata(metadata, {
+        enabled: true,
+        count: 1,
+        types: [type],
+      });
+    }
+  }
+
+  return { value: nextValue ?? value, metadata };
+}
+
+export function redactSessionName(
+  value: string | undefined,
+  config: ResolvedRedactionConfig
+): RedactionResult<string | undefined> {
+  if (!value || !config.enabled || !config.redactSessionNames) {
+    return { value };
+  }
+
+  return redactString(value, config);
+}
+
+export function redactSessionIdentifier(
+  value: string | undefined,
+  config: ResolvedRedactionConfig
+): RedactionResult<string | undefined> {
+  if (!value || !config.enabled) {
+    return { value };
+  }
+
+  const type = detectExactMatchType(value, config);
+  if (!type) {
+    return { value };
+  }
+
+  return {
+    value: createPlaceholder(type, value, true),
+    metadata: {
+      enabled: true,
+      count: 1,
+      types: [type],
+    },
+  };
+}
+
+export function redactErrorInfo(
+  error: { code?: string; message?: string; stack?: string } | undefined,
+  config: ResolvedRedactionConfig
+): RedactionResult<
+  { code?: string; message?: string; stack?: string } | undefined
+> {
+  if (!error || !config.enabled || !config.redactErrors) {
+    return { value: error };
+  }
+
+  const message: RedactionResult<string | undefined> = error.message
+    ? redactString(error.message, config)
+    : { value: error.message };
+  const stack: RedactionResult<string | undefined> = error.stack
+    ? redactString(error.stack, config)
+    : { value: error.stack };
+
+  const metadata = mergeMetadata(message.metadata, stack.metadata);
+  if (!metadata) {
+    return { value: error };
+  }
+
+  return {
+    value: {
+      ...error,
+      message: message.value,
+      stack: stack.value,
+    },
+    metadata,
+  };
+}
+
+export function attachRedactionMetadata(
+  attributes: Record<string, unknown>,
+  metadata?: RedactionMetadata
+): void {
+  if (!metadata) {
+    return;
+  }
+
+  const existing = parseExistingMetadata(attributes[REDACTION_KEY]);
+  attributes[REDACTION_KEY] = existing
+    ? {
+        enabled: true,
+        count: existing.count + metadata.count,
+        types: Array.from(new Set([...existing.types, ...metadata.types])),
+      }
+    : metadata;
+}
+
+export function safeSerialize(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  return JSON.stringify(value, (_key, currentValue) => {
+    if (typeof currentValue === 'bigint') {
+      return currentValue.toString();
+    }
+
+    if (typeof currentValue === 'function') {
+      return `[Function ${currentValue.name || 'anonymous'}]`;
+    }
+
+    if (
+      typeof currentValue === 'object' &&
+      currentValue !== null &&
+      !(currentValue instanceof Date)
+    ) {
+      if (seen.has(currentValue)) {
+        return '[Circular]';
+      }
+      seen.add(currentValue);
+    }
+
+    return currentValue;
+  });
+}
+
+function redactValue(
+  value: unknown,
+  config: ResolvedRedactionConfig
+): RedactionResult<unknown> {
+  if (typeof value === 'string') {
+    if (looksLikeJson(value)) {
+      const parsed = tryParseJson(value);
+      if (parsed !== undefined) {
+        return redactValue(parsed, config);
+      }
+    }
+
+    return redactString(value, config);
+  }
+
+  if (Array.isArray(value)) {
+    return redactArray(value, config);
+  }
+
+  if (value && typeof value === 'object') {
+    return redactObject(value as Record<string, unknown>, config);
+  }
+
+  return { value };
+}
+
+function redactArray(
+  value: unknown[],
+  config: ResolvedRedactionConfig
+): RedactionResult<unknown[]> {
+  let nextValue: unknown[] | undefined;
+  let metadata: RedactionMetadata | undefined;
+
+  value.forEach((item, index) => {
+    const redacted = redactValue(item, config);
+    if (!nextValue && redacted.value !== item) {
+      nextValue = [...value];
+    }
+
+    if (nextValue) {
+      nextValue[index] = redacted.value;
+    }
+
+    metadata = mergeMetadata(metadata, redacted.metadata);
+  });
+
+  return { value: nextValue ?? value, metadata };
+}
+
+function redactObject(
+  value: Record<string, unknown>,
+  config: ResolvedRedactionConfig
+): RedactionResult<Record<string, unknown>> {
+  let nextValue: Record<string, unknown> | undefined;
+  let metadata: RedactionMetadata | undefined;
+
+  for (const [key, rawValue] of Object.entries(value)) {
+    let redacted: RedactionResult<unknown>;
+
+    if (isSensitiveKey(key, config)) {
+      const type = detectRedactionType(rawValue);
+      redacted = {
+        value: createPlaceholder(type, String(rawValue ?? '')),
+        metadata: {
+          enabled: true,
+          count: 1,
+          types: [type],
+        },
+      };
+    } else {
+      redacted = redactValue(rawValue, config);
+    }
+
+    if (!nextValue && redacted.value !== rawValue) {
+      nextValue = { ...value };
+    }
+
+    if (nextValue) {
+      nextValue[key] = redacted.value;
+    }
+
+    metadata = mergeMetadata(metadata, redacted.metadata);
+  }
+
+  return { value: nextValue ?? value, metadata };
+}
+
+function redactString(
+  value: string,
+  config: ResolvedRedactionConfig,
+  options: StringRedactionOptions = {}
+): RedactionResult<string> {
+  let nextValue = value;
+  let metadata: RedactionMetadata | undefined;
+
+  const exactType = options.stable ? detectExactMatchType(value, config) : null;
+  if (exactType) {
+    return {
+      value: createPlaceholder(exactType, value, true),
+      metadata: {
+        enabled: true,
+        count: 1,
+        types: [exactType],
+      },
+    };
+  }
+
+  nextValue = replaceWithMetadata(
+    nextValue,
+    AUTH_HEADER_REGEX,
+    'SECRET',
+    (_match, headerName) => `${headerName}: [REDACTED_SECRET]`,
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    COOKIE_HEADER_REGEX,
+    'SECRET',
+    (_match, headerName) => `${headerName}: [REDACTED_SECRET]`,
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    BEARER_REGEX,
+    'SECRET',
+    () => 'Bearer [REDACTED_SECRET]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    JWT_REGEX,
+    'SECRET',
+    () => '[REDACTED_SECRET]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    API_KEY_REGEX,
+    'SECRET',
+    () => '[REDACTED_SECRET]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replacePanCandidates(nextValue, (metadataRef) => {
+    metadata = mergeMetadata(metadata, metadataRef);
+  });
+  nextValue = replaceWithMetadata(
+    nextValue,
+    SSN_REGEX,
+    'SSN',
+    () => '[REDACTED_SSN]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    EMAIL_REGEX,
+    'EMAIL',
+    () => '[REDACTED_EMAIL]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    PHONE_REGEX,
+    'PHONE',
+    () => '[REDACTED_PHONE]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    IPV4_REGEX,
+    'IP',
+    () => '[REDACTED_IP]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    IPV6_REGEX,
+    'IP',
+    () => '[REDACTED_IP]',
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+
+  for (const pattern of config.customPatterns) {
+    nextValue = replaceWithMetadata(
+      nextValue,
+      pattern,
+      'SECRET',
+      () => '[REDACTED_SECRET]',
+      (metadataRef) => {
+        metadata = mergeMetadata(metadata, metadataRef);
+      }
+    );
+  }
+
+  return {
+    value: nextValue,
+    metadata,
+  };
+}
+
+function replacePanCandidates(
+  value: string,
+  onMatch: (metadata: RedactionMetadata) => void
+): string {
+  PAN_CANDIDATE_REGEX.lastIndex = 0;
+  return value.replace(PAN_CANDIDATE_REGEX, (matched) => {
+    const digits = matched.replace(/[ -]/g, '');
+    if (!isLikelyPan(digits)) {
+      return matched;
+    }
+
+    onMatch({
+      enabled: true,
+      count: 1,
+      types: ['PAN'],
+    });
+    return '[REDACTED_PAN]';
+  });
+}
+
+function replaceWithMetadata(
+  value: string,
+  pattern: RegExp,
+  type: RedactionType,
+  replacement: (...args: string[]) => string,
+  onMatch: (metadata: RedactionMetadata) => void
+): string {
+  pattern.lastIndex = 0;
+  let matched = false;
+  const result = value.replace(pattern, (...args) => {
+    matched = true;
+    return replacement(...(args as string[]));
+  });
+  pattern.lastIndex = 0;
+
+  if (matched) {
+    onMatch({
+      enabled: true,
+      count: 1,
+      types: [type],
+    });
+  }
+
+  return result;
+}
+
+function createPlaceholderForValue(value: unknown): string {
+  return createPlaceholder(detectRedactionType(value), String(value ?? ''));
+}
+
+function createPlaceholder(
+  type: RedactionType,
+  rawValue: string,
+  stable = false
+): string {
+  const base = `[REDACTED_${type}]`;
+  if (!stable) {
+    return base;
+  }
+
+  return `[REDACTED_${type}_${stableHash(rawValue)}]`;
+}
+
+function detectRedactionType(value: unknown): RedactionType {
+  if (typeof value !== 'string') {
+    return 'SECRET';
+  }
+
+  return detectExactMatchType(value, resolveRedactionConfig({ enabled: true }))
+    ? (detectExactMatchType(
+        value,
+        resolveRedactionConfig({ enabled: true })
+      ) as RedactionType)
+    : value.includes('@')
+      ? 'EMAIL'
+      : 'SECRET';
+}
+
+function detectExactMatchType(
+  value: string,
+  config: ResolvedRedactionConfig
+): RedactionType | null {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  if (EMAIL_REGEX.test(trimmed) && EMAIL_REGEX.lastIndex === trimmed.length) {
+    EMAIL_REGEX.lastIndex = 0;
+    return 'EMAIL';
+  }
+  EMAIL_REGEX.lastIndex = 0;
+
+  if (SSN_REGEX.test(trimmed) && SSN_REGEX.lastIndex === trimmed.length) {
+    SSN_REGEX.lastIndex = 0;
+    return 'SSN';
+  }
+  SSN_REGEX.lastIndex = 0;
+
+  if (
+    BEARER_REGEX.test(trimmed) ||
+    JWT_REGEX.test(trimmed) ||
+    API_KEY_REGEX.test(trimmed) ||
+    AUTH_HEADER_REGEX.test(trimmed) ||
+    COOKIE_HEADER_REGEX.test(trimmed)
+  ) {
+    resetGlobalRegexes();
+    return 'SECRET';
+  }
+  resetGlobalRegexes();
+
+  if (IPV4_REGEX.test(trimmed) && IPV4_REGEX.lastIndex === trimmed.length) {
+    IPV4_REGEX.lastIndex = 0;
+    return 'IP';
+  }
+  IPV4_REGEX.lastIndex = 0;
+
+  if (IPV6_REGEX.test(trimmed) && IPV6_REGEX.lastIndex === trimmed.length) {
+    IPV6_REGEX.lastIndex = 0;
+    return 'IP';
+  }
+  IPV6_REGEX.lastIndex = 0;
+
+  const phoneCandidate = trimmed.replace(/[\s().-]/g, '');
+  if (
+    PHONE_REGEX.test(trimmed) &&
+    PHONE_REGEX.lastIndex === trimmed.length &&
+    phoneCandidate.length >= 8 &&
+    phoneCandidate.length <= 15
+  ) {
+    PHONE_REGEX.lastIndex = 0;
+    return 'PHONE';
+  }
+  PHONE_REGEX.lastIndex = 0;
+
+  const panDigits = trimmed.replace(/[ -]/g, '');
+  if (isLikelyPan(panDigits)) {
+    return 'PAN';
+  }
+
+  for (const pattern of config.customPatterns) {
+    if (pattern.test(trimmed)) {
+      pattern.lastIndex = 0;
+      return 'SECRET';
+    }
+    pattern.lastIndex = 0;
+  }
+
+  return null;
+}
+
+function isSensitiveKey(key: string, config: ResolvedRedactionConfig): boolean {
+  const normalized = normalizeKey(key);
+  return config.sensitiveKeys.some(
+    (sensitiveKey) =>
+      normalized === sensitiveKey ||
+      normalized.endsWith(`_${sensitiveKey}`) ||
+      normalized.endsWith(`.${sensitiveKey}`)
+  );
+}
+
+function normalizeCustomPattern(pattern: RegExp | string): RegExp | undefined {
+  if (pattern instanceof RegExp) {
+    const flags = pattern.flags.includes('g')
+      ? pattern.flags
+      : `${pattern.flags}g`;
+    return new RegExp(pattern.source, flags);
+  }
+
+  const inlineMatch = pattern.match(/^\/(.+)\/([dgimsuvy]*)$/);
+  if (inlineMatch) {
+    const flags = inlineMatch[2].includes('g')
+      ? inlineMatch[2]
+      : `${inlineMatch[2]}g`;
+    return new RegExp(inlineMatch[1], flags);
+  }
+
+  return new RegExp(escapeRegExp(pattern), 'g');
+}
+
+function mergeMetadata(
+  left?: RedactionMetadata,
+  right?: RedactionMetadata
+): RedactionMetadata | undefined {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+
+  return {
+    enabled: true,
+    count: left.count + right.count,
+    types: Array.from(new Set([...left.types, ...right.types])),
+  };
+}
+
+function parseExistingMetadata(value: unknown): RedactionMetadata | undefined {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !('enabled' in value) ||
+    !('count' in value) ||
+    !('types' in value)
+  ) {
+    return undefined;
+  }
+
+  const candidate = value as RedactionMetadata;
+  if (
+    candidate.enabled !== true ||
+    typeof candidate.count !== 'number' ||
+    !Array.isArray(candidate.types)
+  ) {
+    return undefined;
+  }
+
+  return candidate;
+}
+
+function tryParseJson(value: string): unknown | undefined {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function looksLikeJson(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith('{') || trimmed.startsWith('[');
+}
+
+function normalizeKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+}
+
+function resetGlobalRegexes(): void {
+  BEARER_REGEX.lastIndex = 0;
+  JWT_REGEX.lastIndex = 0;
+  API_KEY_REGEX.lastIndex = 0;
+  AUTH_HEADER_REGEX.lastIndex = 0;
+  COOKIE_HEADER_REGEX.lastIndex = 0;
+}
+
+function isLikelyPan(value: string): boolean {
+  if (!/^\d{13,19}$/.test(value)) {
+    return false;
+  }
+
+  let sum = 0;
+  let shouldDouble = false;
+
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    let digit = Number(value[index]);
+    if (shouldDouble) {
+      digit *= 2;
+      if (digit > 9) {
+        digit -= 9;
+      }
+    }
+    sum += digit;
+    shouldDouble = !shouldDouble;
+  }
+
+  return sum % 10 === 0;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16);
+}

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -662,15 +662,6 @@ function redactString(
   );
   nextValue = replaceWithMetadata(
     nextValue,
-    PHONE_REGEX,
-    'PHONE',
-    (match) => redactSensitiveValueByType('PHONE', match, referenceContext),
-    (metadataRef) => {
-      metadata = mergeMetadata(metadata, metadataRef);
-    }
-  );
-  nextValue = replaceWithMetadata(
-    nextValue,
     IPV4_REGEX,
     'IP',
     (match) => redactSensitiveValueByType('IP', match, referenceContext),
@@ -683,6 +674,15 @@ function redactString(
     IPV6_REGEX,
     'IP',
     (match) => redactSensitiveValueByType('IP', match, referenceContext),
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    }
+  );
+  nextValue = replaceWithMetadata(
+    nextValue,
+    PHONE_REGEX,
+    'PHONE',
+    (match) => redactSensitiveValueByType('PHONE', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
     }

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -572,8 +572,7 @@ function redactString(
     },
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -587,8 +586,7 @@ function redactString(
       )}`,
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -602,8 +600,7 @@ function redactString(
       )}`,
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -612,8 +609,7 @@ function redactString(
     (match) => redactSensitiveValueByType('SECRET', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -622,8 +618,7 @@ function redactString(
     (match) => redactSensitiveValueByType('SECRET', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replacePanCandidates(
     nextValue,
@@ -639,8 +634,7 @@ function redactString(
     (match) => redactSensitiveValueByType('SSN', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -649,8 +643,7 @@ function redactString(
     (match) => redactSensitiveValueByType('EMAIL', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -659,8 +652,7 @@ function redactString(
     (match) => redactSensitiveValueByType('PHONE', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -669,8 +661,7 @@ function redactString(
     (match) => redactSensitiveValueByType('IP', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
   nextValue = replaceWithMetadata(
     nextValue,
@@ -679,8 +670,7 @@ function redactString(
     (match) => redactSensitiveValueByType('IP', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    },
-    referenceContext
+    }
   );
 
   for (const pattern of config.customPatterns) {
@@ -691,8 +681,7 @@ function redactString(
       (match) => redactSensitiveValueByType('SECRET', match, referenceContext),
       (metadataRef) => {
         metadata = mergeMetadata(metadata, metadataRef);
-      },
-      referenceContext
+      }
     );
   }
 
@@ -728,8 +717,7 @@ function replaceWithMetadata(
   pattern: RegExp,
   type: RedactionType,
   replacement: (...args: string[]) => string,
-  onMatch: (metadata: RedactionMetadata) => void,
-  _referenceContext?: RedactionReferenceContext
+  onMatch: (metadata: RedactionMetadata) => void
 ): string {
   pattern.lastIndex = 0;
   let matchCount = 0;

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -232,13 +232,17 @@ export function redactTags(
 
     if (isSensitiveKey(key, config)) {
       const type = detectRedactionType(rawValue);
+      const redactedValue = redactSensitiveValueByType(
+        type,
+        rawValue,
+        referenceContext
+      );
       redacted = {
-        value: redactSensitiveValueByType(type, rawValue, referenceContext),
-        metadata: {
-          enabled: true,
-          count: 1,
-          types: [type],
-        },
+        value: redactedValue,
+        metadata:
+          redactedValue !== rawValue
+            ? { enabled: true, count: 1, types: [type] }
+            : undefined,
       };
     } else {
       redacted = redactString(rawValue, config, {}, referenceContext);
@@ -466,17 +470,17 @@ function redactObject(
 
       if (isSensitiveKey(key, config)) {
         const type = detectRedactionType(rawValue);
+        const redactedValue = redactSensitiveValueByType(
+          type,
+          rawValue,
+          context.referenceContext
+        );
         redacted = {
-          value: redactSensitiveValueByType(
-            type,
-            rawValue,
-            context.referenceContext
-          ),
-          metadata: {
-            enabled: true,
-            count: 1,
-            types: [type],
-          },
+          value: redactedValue,
+          metadata:
+            redactedValue !== rawValue
+              ? { enabled: true, count: 1, types: [type] }
+              : undefined,
         };
       } else {
         redacted = redactValue(rawValue, config, context);
@@ -834,11 +838,16 @@ function detectExactMatchType(
   }
 
   for (const pattern of config.customPatterns) {
-    if (pattern.test(trimmed)) {
-      pattern.lastIndex = 0;
+    pattern.lastIndex = 0;
+    const customMatch = pattern.exec(trimmed);
+    pattern.lastIndex = 0;
+    if (
+      customMatch &&
+      customMatch.index === 0 &&
+      customMatch[0].length === trimmed.length
+    ) {
       return 'SECRET';
     }
-    pattern.lastIndex = 0;
   }
 
   return null;

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -58,7 +58,8 @@ const IPV6_REGEX =
 const JWT_REGEX = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\b/g;
 const API_KEY_REGEX =
   /\b(?:sk|pk|rk|ghp|gho|ghu|ghs|github_pat|xox[baprs]-|AIza|ya29|AKIA|ASIA)[A-Za-z0-9._-]{8,}\b/g;
-const BEARER_REGEX = /\bBearer\s+[A-Za-z0-9\-._~+/]+=*\b/gi;
+const BEARER_REGEX =
+  /\bBearer\s+[A-Za-z0-9\-._~+/]+=*(?=[^A-Za-z0-9\-._~+/=]|$)/gi;
 const AUTH_HEADER_REGEX =
   /\b(authorization|proxy-authorization)\s*([:=])\s*([^\r\n]+)/gi;
 const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*([:=])\s*([^\r\n]+)/gi;
@@ -796,7 +797,12 @@ function redactSensitiveValueByType(
   rawValue: unknown,
   referenceContext?: RedactionReferenceContext
 ): string {
-  const rawString = String(rawValue ?? '');
+  const rawString =
+    typeof rawValue === 'string'
+      ? rawValue
+      : rawValue != null && typeof rawValue === 'object'
+        ? safeSerialize(rawValue)
+        : String(rawValue ?? '');
   if (isExactPlaceholder(rawString)) {
     return rawString;
   }

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -113,7 +113,6 @@ export function resolveRedactionConfig(
   }
 
   const enabled = config?.enabled ?? false;
-
   return {
     _resolved: true,
     enabled,
@@ -1025,10 +1024,11 @@ function looksLikeJson(value: string): boolean {
 function normalizeKey(value: string): string {
   return value
     .trim()
+    .replace(/([A-Z]+)([A-Z][a-z0-9]+)/g, '$1_$2')
     .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
     .toLowerCase()
-    .replace(/[\s-]+/g, '_');
+    .replace(/[\s./-]+/g, '_')
+    .replace(/_+/g, '_');
 }
 
 function resetGlobalRegexes(): void {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -60,8 +60,8 @@ const API_KEY_REGEX =
   /\b(?:sk|pk|rk|ghp|gho|ghu|ghs|github_pat|xox[baprs]-|AIza|ya29|AKIA|ASIA)[A-Za-z0-9._-]{8,}\b/g;
 const BEARER_REGEX = /\bBearer\s+[A-Za-z0-9\-._~+/]+=*\b/gi;
 const AUTH_HEADER_REGEX =
-  /\b(authorization|proxy-authorization)\s*[:=]\s*([^\r\n]+)/gi;
-const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*[:=]\s*([^\r\n]+)/gi;
+  /\b(authorization|proxy-authorization)\s*([:=])\s*([^\r\n]+)/gi;
+const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*([:=])\s*([^\r\n]+)/gi;
 const PHONE_REGEX = /(?:\+?\d[\d().\s-]{7,}\d)/g;
 const PAN_CANDIDATE_REGEX = /\b(?:\d[ -]?){13,19}\b/g;
 const EXACT_PLACEHOLDER_REGEX = /^\[REDACTED_[A-Z]+(?:_[A-Z0-9]+)?\]$/;
@@ -474,8 +474,8 @@ function redactString(
     nextValue,
     AUTH_HEADER_REGEX,
     'SECRET',
-    (_match, headerName, headerValue) =>
-      `${headerName}: ${redactSensitiveValueByType(
+    (_match, headerName, separator, headerValue) =>
+      `${headerName}${separator} ${redactSensitiveValueByType(
         'SECRET',
         headerValue,
         referenceContext
@@ -489,8 +489,8 @@ function redactString(
     nextValue,
     COOKIE_HEADER_REGEX,
     'SECRET',
-    (_match, headerName, headerValue) =>
-      `${headerName}: ${redactSensitiveValueByType(
+    (_match, headerName, separator, headerValue) =>
+      `${headerName}${separator} ${redactSensitiveValueByType(
         'SECRET',
         headerValue,
         referenceContext

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -47,6 +47,7 @@ type RedactionType = 'EMAIL' | 'PHONE' | 'SSN' | 'PAN' | 'SECRET' | 'IP';
 
 type StringRedactionOptions = {
   stable?: boolean;
+  parseJsonStrings?: boolean;
 };
 
 const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
@@ -150,6 +151,23 @@ export function redactOutputValue(
     return { value };
   }
   return redactValue(value, config, createTraversalContext(referenceContext));
+}
+
+export function redactTextValue(
+  value: string,
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
+): RedactionResult<string> {
+  if (!config.enabled) {
+    return { value };
+  }
+
+  return redactString(
+    value,
+    config,
+    { parseJsonStrings: false },
+    referenceContext
+  );
 }
 
 export function redactAttributes(
@@ -438,7 +456,9 @@ function redactObject(
         nextValue[key] = redacted.value;
       }
 
-      metadata = mergeMetadata(metadata, redacted.metadata);
+      if (redacted.value !== rawValue) {
+        metadata = mergeMetadata(metadata, redacted.metadata);
+      }
     }
   } finally {
     context.visiting.delete(value);
@@ -466,6 +486,10 @@ function redactString(
     return { value };
   }
 
+  if (options.parseJsonStrings === undefined) {
+    options.parseJsonStrings = true;
+  }
+
   let nextValue = value;
   let metadata: RedactionMetadata | undefined;
 
@@ -479,6 +503,24 @@ function redactString(
         types: [exactType],
       },
     };
+  }
+
+  if (options.parseJsonStrings && looksLikeJson(value)) {
+    const parsed = tryParseJson(value);
+    if (parsed !== undefined) {
+      const redacted = redactValue(
+        parsed,
+        config,
+        createTraversalContext(referenceContext)
+      );
+      return {
+        value:
+          typeof redacted.value === 'string'
+            ? redacted.value
+            : safeSerialize(redacted.value),
+        metadata: redacted.metadata,
+      };
+    }
   }
 
   nextValue = replaceWithMetadata(

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -175,29 +175,32 @@ export function redactTags(
   let metadata: RedactionMetadata | undefined;
 
   for (const [key, rawValue] of Object.entries(value)) {
-    const redactedValue = isSensitiveKey(key, config)
-      ? redactSensitiveValueByType(
-          detectRedactionType(rawValue),
-          rawValue,
-          referenceContext
-        )
-      : redactString(rawValue, config, {}, referenceContext).value;
+    let redacted: RedactionResult<string>;
 
-    if (!nextValue && redactedValue !== rawValue) {
+    if (isSensitiveKey(key, config)) {
+      const type = detectRedactionType(rawValue);
+      redacted = {
+        value: redactSensitiveValueByType(type, rawValue, referenceContext),
+        metadata: {
+          enabled: true,
+          count: 1,
+          types: [type],
+        },
+      };
+    } else {
+      redacted = redactString(rawValue, config, {}, referenceContext);
+    }
+
+    if (!nextValue && redacted.value !== rawValue) {
       nextValue = { ...value };
     }
 
     if (nextValue) {
-      nextValue[key] = redactedValue;
+      nextValue[key] = redacted.value;
     }
 
-    if (redactedValue !== rawValue) {
-      const type = detectRedactionType(rawValue);
-      metadata = mergeMetadata(metadata, {
-        enabled: true,
-        count: 1,
-        types: [type],
-      });
+    if (redacted.value !== rawValue) {
+      metadata = mergeMetadata(metadata, redacted.metadata);
     }
   }
 

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -28,6 +28,11 @@ export interface RedactionMetadata {
   types: string[];
 }
 
+export interface RedactionReferenceContext {
+  placeholders: Partial<Record<RedactionType, Map<string, string>>>;
+  counters: Partial<Record<RedactionType, number>>;
+}
+
 type RedactionResult<T> = {
   value: T;
   metadata?: RedactionMetadata;
@@ -35,6 +40,7 @@ type RedactionResult<T> = {
 
 type RedactionTraversalContext = {
   visiting: WeakSet<object>;
+  referenceContext?: RedactionReferenceContext;
 };
 
 type RedactionType = 'EMAIL' | 'PHONE' | 'SSN' | 'PAN' | 'SECRET' | 'IP';
@@ -58,6 +64,7 @@ const AUTH_HEADER_REGEX =
 const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*[:=]\s*[^\r\n]+/gi;
 const PHONE_REGEX = /(?:\+?\d[\d().\s-]{7,}\d)/g;
 const PAN_CANDIDATE_REGEX = /\b(?:\d[ -]?){13,19}\b/g;
+const EXACT_PLACEHOLDER_REGEX = /^\[REDACTED_[A-Z]+(?:_[A-Z0-9]+)?\]$/;
 
 const DEFAULT_SENSITIVE_KEYS = [
   'email',
@@ -115,39 +122,50 @@ export function resolveRedactionConfig(
   };
 }
 
+export function createRedactionReferenceContext(): RedactionReferenceContext {
+  return {
+    placeholders: {},
+    counters: {},
+  };
+}
+
 export function redactInputValue(
   value: unknown,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<unknown> {
   if (!config.enabled || !config.redactInputs) {
     return { value };
   }
-  return redactValue(value, config, createTraversalContext());
+  return redactValue(value, config, createTraversalContext(referenceContext));
 }
 
 export function redactOutputValue(
   value: unknown,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<unknown> {
   if (!config.enabled || !config.redactOutputs) {
     return { value };
   }
-  return redactValue(value, config, createTraversalContext());
+  return redactValue(value, config, createTraversalContext(referenceContext));
 }
 
 export function redactAttributes(
   value: Record<string, unknown> | undefined,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<Record<string, unknown> | undefined> {
   if (!value || !config.enabled || !config.redactAttributes) {
     return { value };
   }
-  return redactObject(value, config, createTraversalContext());
+  return redactObject(value, config, createTraversalContext(referenceContext));
 }
 
 export function redactTags(
   value: Record<string, string> | undefined,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<Record<string, string> | undefined> {
   if (!value || !config.enabled || !config.redactTagValues) {
     return { value };
@@ -158,8 +176,12 @@ export function redactTags(
 
   for (const [key, rawValue] of Object.entries(value)) {
     const redactedValue = isSensitiveKey(key, config)
-      ? createPlaceholderForValue(rawValue)
-      : redactString(rawValue, config).value;
+      ? redactSensitiveValueByType(
+          detectRedactionType(rawValue),
+          rawValue,
+          referenceContext
+        )
+      : redactString(rawValue, config, {}, referenceContext).value;
 
     if (!nextValue && redactedValue !== rawValue) {
       nextValue = { ...value };
@@ -184,20 +206,26 @@ export function redactTags(
 
 export function redactSessionName(
   value: string | undefined,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<string | undefined> {
   if (!value || !config.enabled || !config.redactSessionNames) {
     return { value };
   }
 
-  return redactString(value, config);
+  return redactString(value, config, {}, referenceContext);
 }
 
 export function redactSessionIdentifier(
   value: string | undefined,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<string | undefined> {
   if (!value || !config.enabled) {
+    return { value };
+  }
+
+  if (isExactPlaceholder(value)) {
     return { value };
   }
 
@@ -207,7 +235,7 @@ export function redactSessionIdentifier(
   }
 
   return {
-    value: createPlaceholder(type, value, true),
+    value: redactSensitiveValueByType(type, value, referenceContext),
     metadata: {
       enabled: true,
       count: 1,
@@ -218,7 +246,8 @@ export function redactSessionIdentifier(
 
 export function redactErrorInfo(
   error: { code?: string; message?: string; stack?: string } | undefined,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<
   { code?: string; message?: string; stack?: string } | undefined
 > {
@@ -227,10 +256,10 @@ export function redactErrorInfo(
   }
 
   const message: RedactionResult<string | undefined> = error.message
-    ? redactString(error.message, config)
+    ? redactString(error.message, config, {}, referenceContext)
     : { value: error.message };
   const stack: RedactionResult<string | undefined> = error.stack
-    ? redactString(error.stack, config)
+    ? redactString(error.stack, config, {}, referenceContext)
     : { value: error.stack };
 
   const metadata = mergeMetadata(message.metadata, stack.metadata);
@@ -306,7 +335,7 @@ function redactValue(
       }
     }
 
-    return redactString(value, config);
+    return redactString(value, config, {}, context.referenceContext);
   }
 
   if (Array.isArray(value)) {
@@ -375,7 +404,11 @@ function redactObject(
       if (isSensitiveKey(key, config)) {
         const type = detectRedactionType(rawValue);
         redacted = {
-          value: createPlaceholder(type, String(rawValue ?? '')),
+          value: redactSensitiveValueByType(
+            type,
+            rawValue,
+            context.referenceContext
+          ),
           metadata: {
             enabled: true,
             count: 1,
@@ -403,24 +436,32 @@ function redactObject(
   return { value: nextValue ?? value, metadata };
 }
 
-function createTraversalContext(): RedactionTraversalContext {
+function createTraversalContext(
+  referenceContext?: RedactionReferenceContext
+): RedactionTraversalContext {
   return {
     visiting: new WeakSet<object>(),
+    referenceContext,
   };
 }
 
 function redactString(
   value: string,
   config: ResolvedRedactionConfig,
-  options: StringRedactionOptions = {}
+  options: StringRedactionOptions = {},
+  referenceContext?: RedactionReferenceContext
 ): RedactionResult<string> {
+  if (isExactPlaceholder(value)) {
+    return { value };
+  }
+
   let nextValue = value;
   let metadata: RedactionMetadata | undefined;
 
   const exactType = options.stable ? detectExactMatchType(value, config) : null;
   if (exactType) {
     return {
-      value: createPlaceholder(exactType, value, true),
+      value: redactSensitiveValueByType(exactType, value, referenceContext),
       metadata: {
         enabled: true,
         count: 1,
@@ -433,94 +474,123 @@ function redactString(
     nextValue,
     AUTH_HEADER_REGEX,
     'SECRET',
-    (_match, headerName) => `${headerName}: [REDACTED_SECRET]`,
+    (_match, headerName, headerValue) =>
+      `${headerName}: ${redactSensitiveValueByType(
+        'SECRET',
+        headerValue,
+        referenceContext
+      )}`,
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     COOKIE_HEADER_REGEX,
     'SECRET',
-    (_match, headerName) => `${headerName}: [REDACTED_SECRET]`,
+    (_match, headerName, headerValue) =>
+      `${headerName}: ${redactSensitiveValueByType(
+        'SECRET',
+        headerValue,
+        referenceContext
+      )}`,
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     BEARER_REGEX,
     'SECRET',
-    () => 'Bearer [REDACTED_SECRET]',
+    (match) =>
+      `Bearer ${redactSensitiveValueByType(
+        'SECRET',
+        match.replace(/^Bearer\s+/i, ''),
+        referenceContext
+      )}`,
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     JWT_REGEX,
     'SECRET',
-    () => '[REDACTED_SECRET]',
+    (match) => redactSensitiveValueByType('SECRET', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     API_KEY_REGEX,
     'SECRET',
-    () => '[REDACTED_SECRET]',
+    (match) => redactSensitiveValueByType('SECRET', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
-  nextValue = replacePanCandidates(nextValue, (metadataRef) => {
-    metadata = mergeMetadata(metadata, metadataRef);
-  });
+  nextValue = replacePanCandidates(
+    nextValue,
+    (metadataRef) => {
+      metadata = mergeMetadata(metadata, metadataRef);
+    },
+    referenceContext
+  );
   nextValue = replaceWithMetadata(
     nextValue,
     SSN_REGEX,
     'SSN',
-    () => '[REDACTED_SSN]',
+    (match) => redactSensitiveValueByType('SSN', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     EMAIL_REGEX,
     'EMAIL',
-    () => '[REDACTED_EMAIL]',
+    (match) => redactSensitiveValueByType('EMAIL', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     PHONE_REGEX,
     'PHONE',
-    () => '[REDACTED_PHONE]',
+    (match) => redactSensitiveValueByType('PHONE', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     IPV4_REGEX,
     'IP',
-    () => '[REDACTED_IP]',
+    (match) => redactSensitiveValueByType('IP', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
   nextValue = replaceWithMetadata(
     nextValue,
     IPV6_REGEX,
     'IP',
-    () => '[REDACTED_IP]',
+    (match) => redactSensitiveValueByType('IP', match, referenceContext),
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
-    }
+    },
+    referenceContext
   );
 
   for (const pattern of config.customPatterns) {
@@ -528,10 +598,11 @@ function redactString(
       nextValue,
       pattern,
       'SECRET',
-      () => '[REDACTED_SECRET]',
+      (match) => redactSensitiveValueByType('SECRET', match, referenceContext),
       (metadataRef) => {
         metadata = mergeMetadata(metadata, metadataRef);
-      }
+      },
+      referenceContext
     );
   }
 
@@ -543,7 +614,8 @@ function redactString(
 
 function replacePanCandidates(
   value: string,
-  onMatch: (metadata: RedactionMetadata) => void
+  onMatch: (metadata: RedactionMetadata) => void,
+  referenceContext?: RedactionReferenceContext
 ): string {
   PAN_CANDIDATE_REGEX.lastIndex = 0;
   return value.replace(PAN_CANDIDATE_REGEX, (matched) => {
@@ -557,7 +629,7 @@ function replacePanCandidates(
       count: 1,
       types: ['PAN'],
     });
-    return '[REDACTED_PAN]';
+    return redactSensitiveValueByType('PAN', matched, referenceContext);
   });
 }
 
@@ -566,20 +638,21 @@ function replaceWithMetadata(
   pattern: RegExp,
   type: RedactionType,
   replacement: (...args: string[]) => string,
-  onMatch: (metadata: RedactionMetadata) => void
+  onMatch: (metadata: RedactionMetadata) => void,
+  _referenceContext?: RedactionReferenceContext
 ): string {
   pattern.lastIndex = 0;
-  let matched = false;
+  let matchCount = 0;
   const result = value.replace(pattern, (...args) => {
-    matched = true;
+    matchCount += 1;
     return replacement(...(args as string[]));
   });
   pattern.lastIndex = 0;
 
-  if (matched) {
+  if (matchCount > 0) {
     onMatch({
       enabled: true,
-      count: 1,
+      count: matchCount,
       types: [type],
     });
   }
@@ -588,20 +661,11 @@ function replaceWithMetadata(
 }
 
 function createPlaceholderForValue(value: unknown): string {
-  return createPlaceholder(detectRedactionType(value), String(value ?? ''));
+  return redactSensitiveValueByType(detectRedactionType(value), value);
 }
 
-function createPlaceholder(
-  type: RedactionType,
-  rawValue: string,
-  stable = false
-): string {
-  const base = `[REDACTED_${type}]`;
-  if (!stable) {
-    return base;
-  }
-
-  return `[REDACTED_${type}_${stableHash(rawValue)}]`;
+function createPlaceholder(type: RedactionType, suffix?: string): string {
+  return suffix ? `[REDACTED_${type}_${suffix}]` : `[REDACTED_${type}]`;
 }
 
 function detectRedactionType(value: unknown): RedactionType {
@@ -722,6 +786,80 @@ function isSensitiveKey(key: string, config: ResolvedRedactionConfig): boolean {
   );
 }
 
+function redactSensitiveValueByType(
+  type: RedactionType,
+  rawValue: unknown,
+  referenceContext?: RedactionReferenceContext
+): string {
+  const rawString = String(rawValue ?? '');
+  if (isExactPlaceholder(rawString)) {
+    return rawString;
+  }
+
+  const normalized = normalizeSensitiveValue(type, rawString);
+  if (!normalized) {
+    return createPlaceholder(type);
+  }
+
+  if (!referenceContext) {
+    return createPlaceholder(type);
+  }
+
+  const mapping =
+    referenceContext.placeholders[type] ??
+    (referenceContext.placeholders[type] = new Map<string, string>());
+  const existing = mapping.get(normalized);
+  if (existing) {
+    return existing;
+  }
+
+  const nextIndex = (referenceContext.counters[type] ?? 0) + 1;
+  referenceContext.counters[type] = nextIndex;
+  const placeholder = createPlaceholder(type, toPlaceholderSuffix(nextIndex));
+  mapping.set(normalized, placeholder);
+  return placeholder;
+}
+
+function normalizeSensitiveValue(type: RedactionType, value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || isExactPlaceholder(trimmed)) {
+    return trimmed;
+  }
+
+  switch (type) {
+    case 'EMAIL':
+      return trimmed.toLowerCase();
+    case 'PHONE':
+      return trimmed.replace(/\D/g, '');
+    case 'SSN':
+      return trimmed.replace(/\D/g, '');
+    case 'PAN':
+      return trimmed.replace(/\D/g, '');
+    case 'IP':
+      return trimmed.toLowerCase();
+    case 'SECRET':
+    default:
+      return trimmed;
+  }
+}
+
+function isExactPlaceholder(value: string): boolean {
+  return EXACT_PLACEHOLDER_REGEX.test(value.trim());
+}
+
+function toPlaceholderSuffix(index: number): string {
+  let current = index;
+  let suffix = '';
+
+  while (current > 0) {
+    current -= 1;
+    suffix = String.fromCharCode(65 + (current % 26)) + suffix;
+    current = Math.floor(current / 26);
+  }
+
+  return suffix || 'A';
+}
+
 function normalizeCustomPattern(pattern: RegExp | string): RegExp | undefined {
   if (pattern instanceof RegExp) {
     const flags = pattern.flags.includes('g')
@@ -835,13 +973,4 @@ function isLikelyPan(value: string): boolean {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function stableHash(value: string): string {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16);
 }

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -398,7 +398,12 @@ function redactValue(
       }
     }
 
-    return redactString(value, config, {}, context.referenceContext);
+    return redactString(
+      value,
+      config,
+      { parseJsonStrings: false },
+      context.referenceContext
+    );
   }
 
   if (Array.isArray(value)) {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -172,7 +172,7 @@ export function redactInputTextValue(
     return { value };
   }
 
-  return redactStringValue(value, config, referenceContext);
+  return redactStringValue(value, config, referenceContext, true);
 }
 
 export function redactOutputTextValue(
@@ -184,24 +184,20 @@ export function redactOutputTextValue(
     return { value };
   }
 
-  return redactStringValue(value, config, referenceContext);
+  return redactStringValue(value, config, referenceContext, true);
 }
 
 function redactStringValue(
   value: string,
   config: ResolvedRedactionConfig,
-  referenceContext?: RedactionReferenceContext
+  referenceContext?: RedactionReferenceContext,
+  parseJsonStrings = false
 ): RedactionResult<string> {
   if (!config.enabled) {
     return { value };
   }
 
-  return redactString(
-    value,
-    config,
-    { parseJsonStrings: false },
-    referenceContext
-  );
+  return redactString(value, config, { parseJsonStrings }, referenceContext);
 }
 
 export function redactAttributes(
@@ -838,14 +834,7 @@ function detectExactMatchType(
   }
 
   for (const pattern of config.customPatterns) {
-    pattern.lastIndex = 0;
-    const customMatch = pattern.exec(trimmed);
-    pattern.lastIndex = 0;
-    if (
-      customMatch &&
-      customMatch.index === 0 &&
-      customMatch[0].length === trimmed.length
-    ) {
+    if (exactMatchesEntireString(pattern, trimmed)) {
       return 'SECRET';
     }
   }

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -234,19 +234,23 @@ export function redactTags(
     let redacted: RedactionResult<string>;
 
     if (isSensitiveKey(key, config)) {
-      const type = detectRedactionType(rawValue);
-      const redactedValue = redactSensitiveValueByType(
-        type,
-        rawValue,
-        referenceContext
-      );
-      redacted = {
-        value: redactedValue,
-        metadata:
-          redactedValue !== rawValue
-            ? { enabled: true, count: 1, types: [type] }
-            : undefined,
-      };
+      if (!hasRedactableSensitiveValue(rawValue)) {
+        redacted = { value: rawValue };
+      } else {
+        const type = detectRedactionType(rawValue);
+        const redactedValue = redactSensitiveValueByType(
+          type,
+          rawValue,
+          referenceContext
+        );
+        redacted = {
+          value: redactedValue,
+          metadata:
+            redactedValue !== rawValue
+              ? { enabled: true, count: 1, types: [type] }
+              : undefined,
+        };
+      }
     } else {
       redacted = redactString(rawValue, config, {}, referenceContext);
     }
@@ -477,19 +481,23 @@ function redactObject(
       let redacted: RedactionResult<unknown>;
 
       if (isSensitiveKey(key, config)) {
-        const type = detectRedactionType(rawValue);
-        const redactedValue = redactSensitiveValueByType(
-          type,
-          rawValue,
-          context.referenceContext
-        );
-        redacted = {
-          value: redactedValue,
-          metadata:
-            redactedValue !== rawValue
-              ? { enabled: true, count: 1, types: [type] }
-              : undefined,
-        };
+        if (!hasRedactableSensitiveValue(rawValue)) {
+          redacted = { value: rawValue };
+        } else {
+          const type = detectRedactionType(rawValue);
+          const redactedValue = redactSensitiveValueByType(
+            type,
+            rawValue,
+            context.referenceContext
+          );
+          redacted = {
+            value: redactedValue,
+            metadata:
+              redactedValue !== rawValue
+                ? { enabled: true, count: 1, types: [type] }
+                : undefined,
+          };
+        }
       } else {
         redacted = redactValue(rawValue, config, context);
       }
@@ -1022,6 +1030,18 @@ function normalizeKey(value: string): string {
     .toLowerCase()
     .replace(/[\s./-]+/g, '_')
     .replace(/_+/g, '_');
+}
+
+function hasRedactableSensitiveValue(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  return true;
 }
 
 function exactMatchesEntireString(regex: RegExp, value: string): boolean {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -61,9 +61,16 @@ const API_KEY_REGEX =
   /\b(?:sk|pk|rk|ghp|gho|ghu|ghs|github_pat|xox[baprs]-|AIza|ya29|AKIA|ASIA)[A-Za-z0-9._-]{8,}\b/g;
 const BEARER_REGEX =
   /\bBearer\s+[A-Za-z0-9\-._~+/]+=*(?=[^A-Za-z0-9\-._~+/=]|$)/gi;
-const AUTH_HEADER_REGEX =
-  /\b(authorization|proxy-authorization)\s*([:=])\s*([^\r\n]+)/gi;
-const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*([:=])\s*([^\r\n]+)/gi;
+const HEADER_BOUNDARY =
+  '(?=\\s*[;,]\\s*(?:authorization|proxy-authorization|cookie|set-cookie)\\s*[:=]|[\\r\\n]|$)';
+const AUTH_HEADER_REGEX = new RegExp(
+  `\\b(authorization|proxy-authorization)\\s*([:=])\\s*([^\\r\\n]+?)${HEADER_BOUNDARY}`,
+  'gi'
+);
+const COOKIE_HEADER_REGEX = new RegExp(
+  `\\b(set-cookie|cookie)\\s*([:=])\\s*([^\\r\\n]+?)${HEADER_BOUNDARY}`,
+  'gi'
+);
 const PHONE_REGEX = /(?:\+?\d[\d().\s-]{7,}\d)/g;
 const PAN_CANDIDATE_REGEX = /\b(?:\d[ -]?){13,19}\b/g;
 const EXACT_PLACEHOLDER_REGEX = /^\[REDACTED_[A-Z]+(?:_[A-Z0-9]+)?\]$/;
@@ -872,7 +879,7 @@ function redactSensitiveValueByType(
 
   const normalized = normalizeSensitiveValue(type, rawString);
   if (!normalized) {
-    return createPlaceholder(type);
+    return rawString;
   }
 
   if (!referenceContext) {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -626,17 +626,27 @@ function detectExactMatchType(
     return null;
   }
 
-  if (EMAIL_REGEX.test(trimmed) && EMAIL_REGEX.lastIndex === trimmed.length) {
-    EMAIL_REGEX.lastIndex = 0;
+  EMAIL_REGEX.lastIndex = 0;
+  const emailMatch = EMAIL_REGEX.exec(trimmed);
+  EMAIL_REGEX.lastIndex = 0;
+  if (
+    emailMatch &&
+    emailMatch.index === 0 &&
+    emailMatch.index + emailMatch[0].length === trimmed.length
+  ) {
     return 'EMAIL';
   }
-  EMAIL_REGEX.lastIndex = 0;
 
-  if (SSN_REGEX.test(trimmed) && SSN_REGEX.lastIndex === trimmed.length) {
-    SSN_REGEX.lastIndex = 0;
+  SSN_REGEX.lastIndex = 0;
+  const ssnMatch = SSN_REGEX.exec(trimmed);
+  SSN_REGEX.lastIndex = 0;
+  if (
+    ssnMatch &&
+    ssnMatch.index === 0 &&
+    ssnMatch.index + ssnMatch[0].length === trimmed.length
+  ) {
     return 'SSN';
   }
-  SSN_REGEX.lastIndex = 0;
 
   if (
     BEARER_REGEX.test(trimmed) ||
@@ -650,29 +660,41 @@ function detectExactMatchType(
   }
   resetGlobalRegexes();
 
-  if (IPV4_REGEX.test(trimmed) && IPV4_REGEX.lastIndex === trimmed.length) {
-    IPV4_REGEX.lastIndex = 0;
-    return 'IP';
-  }
   IPV4_REGEX.lastIndex = 0;
-
-  if (IPV6_REGEX.test(trimmed) && IPV6_REGEX.lastIndex === trimmed.length) {
-    IPV6_REGEX.lastIndex = 0;
+  const ipv4Match = IPV4_REGEX.exec(trimmed);
+  IPV4_REGEX.lastIndex = 0;
+  if (
+    ipv4Match &&
+    ipv4Match.index === 0 &&
+    ipv4Match.index + ipv4Match[0].length === trimmed.length
+  ) {
     return 'IP';
   }
+
   IPV6_REGEX.lastIndex = 0;
+  const ipv6Match = IPV6_REGEX.exec(trimmed);
+  IPV6_REGEX.lastIndex = 0;
+  if (
+    ipv6Match &&
+    ipv6Match.index === 0 &&
+    ipv6Match.index + ipv6Match[0].length === trimmed.length
+  ) {
+    return 'IP';
+  }
 
   const phoneCandidate = trimmed.replace(/[\s().-]/g, '');
+  PHONE_REGEX.lastIndex = 0;
+  const phoneMatch = PHONE_REGEX.exec(trimmed);
+  PHONE_REGEX.lastIndex = 0;
   if (
-    PHONE_REGEX.test(trimmed) &&
-    PHONE_REGEX.lastIndex === trimmed.length &&
+    phoneMatch &&
+    phoneMatch.index === 0 &&
+    phoneMatch.index + phoneMatch[0].length === trimmed.length &&
     phoneCandidate.length >= 8 &&
     phoneCandidate.length <= 15
   ) {
-    PHONE_REGEX.lastIndex = 0;
     return 'PHONE';
   }
-  PHONE_REGEX.lastIndex = 0;
 
   const panDigits = trimmed.replace(/[ -]/g, '');
   if (isLikelyPan(panDigits)) {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -11,6 +11,7 @@ export interface RedactionConfig {
 }
 
 export interface ResolvedRedactionConfig {
+  _resolved: true;
   enabled: boolean;
   redactInputs: boolean;
   redactOutputs: boolean;
@@ -101,18 +102,7 @@ const REDACTION_KEY = 'zeroeval_redaction';
 function isResolvedRedactionConfig(
   config?: Partial<RedactionConfig> | ResolvedRedactionConfig
 ): config is ResolvedRedactionConfig {
-  return (
-    !!config &&
-    typeof config.enabled === 'boolean' &&
-    typeof config.redactInputs === 'boolean' &&
-    typeof config.redactOutputs === 'boolean' &&
-    typeof config.redactAttributes === 'boolean' &&
-    typeof config.redactErrors === 'boolean' &&
-    typeof config.redactSessionNames === 'boolean' &&
-    typeof config.redactTagValues === 'boolean' &&
-    Array.isArray(config.sensitiveKeys) &&
-    Array.isArray(config.customPatterns)
-  );
+  return !!config && '_resolved' in config && config._resolved === true;
 }
 
 export function resolveRedactionConfig(
@@ -125,6 +115,7 @@ export function resolveRedactionConfig(
   const enabled = config?.enabled ?? false;
 
   return {
+    _resolved: true,
     enabled,
     redactInputs: enabled && (config?.redactInputs ?? true),
     redactOutputs: enabled && (config?.redactOutputs ?? true),
@@ -977,7 +968,7 @@ function normalizeCustomPattern(pattern: RegExp | string): RegExp | undefined {
   return new RegExp(escapeRegExp(pattern), 'g');
 }
 
-function mergeMetadata(
+export function mergeMetadata(
   left?: RedactionMetadata,
   right?: RedactionMetadata
 ): RedactionMetadata | undefined {
@@ -1034,6 +1025,8 @@ function looksLikeJson(value: string): boolean {
 function normalizeKey(value: string): string {
   return value
     .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
     .toLowerCase()
     .replace(/[\s-]+/g, '_');
 }

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -60,8 +60,8 @@ const API_KEY_REGEX =
   /\b(?:sk|pk|rk|ghp|gho|ghu|ghs|github_pat|xox[baprs]-|AIza|ya29|AKIA|ASIA)[A-Za-z0-9._-]{8,}\b/g;
 const BEARER_REGEX = /\bBearer\s+[A-Za-z0-9\-._~+/]+=*\b/gi;
 const AUTH_HEADER_REGEX =
-  /\b(authorization|proxy-authorization)\s*[:=]\s*[^\r\n]+/gi;
-const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*[:=]\s*[^\r\n]+/gi;
+  /\b(authorization|proxy-authorization)\s*[:=]\s*([^\r\n]+)/gi;
+const COOKIE_HEADER_REGEX = /\b(set-cookie|cookie)\s*[:=]\s*([^\r\n]+)/gi;
 const PHONE_REGEX = /(?:\+?\d[\d().\s-]{7,}\d)/g;
 const PAN_CANDIDATE_REGEX = /\b(?:\d[ -]?){13,19}\b/g;
 const EXACT_PLACEHOLDER_REGEX = /^\[REDACTED_[A-Z]+(?:_[A-Z0-9]+)?\]$/;
@@ -658,10 +658,6 @@ function replaceWithMetadata(
   }
 
   return result;
-}
-
-function createPlaceholderForValue(value: unknown): string {
-  return redactSensitiveValueByType(detectRedactionType(value), value);
 }
 
 function createPlaceholder(type: RedactionType, suffix?: string): string {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -47,7 +47,6 @@ type RedactionTraversalContext = {
 type RedactionType = 'EMAIL' | 'PHONE' | 'SSN' | 'PAN' | 'SECRET' | 'IP';
 
 type StringRedactionOptions = {
-  stable?: boolean;
   parseJsonStrings?: boolean;
 };
 
@@ -528,18 +527,6 @@ function redactString(
   let nextValue = value;
   let metadata: RedactionMetadata | undefined;
 
-  const exactType = options.stable ? detectExactMatchType(value, config) : null;
-  if (exactType) {
-    return {
-      value: redactSensitiveValueByType(exactType, value, referenceContext),
-      metadata: {
-        enabled: true,
-        count: 1,
-        types: [exactType],
-      },
-    };
-  }
-
   if (options.parseJsonStrings && looksLikeJson(value)) {
     const parsed = tryParseJson(value);
     if (parsed !== undefined) {
@@ -796,16 +783,14 @@ function detectExactMatchType(
   }
 
   if (
-    BEARER_REGEX.test(trimmed) ||
-    JWT_REGEX.test(trimmed) ||
-    API_KEY_REGEX.test(trimmed) ||
-    AUTH_HEADER_REGEX.test(trimmed) ||
-    COOKIE_HEADER_REGEX.test(trimmed)
+    exactMatchesEntireString(BEARER_REGEX, trimmed) ||
+    exactMatchesEntireString(JWT_REGEX, trimmed) ||
+    exactMatchesEntireString(API_KEY_REGEX, trimmed) ||
+    exactMatchesEntireString(AUTH_HEADER_REGEX, trimmed) ||
+    exactMatchesEntireString(COOKIE_HEADER_REGEX, trimmed)
   ) {
-    resetGlobalRegexes();
     return 'SECRET';
   }
-  resetGlobalRegexes();
 
   IPV4_REGEX.lastIndex = 0;
   const ipv4Match = IPV4_REGEX.exec(trimmed);
@@ -1031,12 +1016,11 @@ function normalizeKey(value: string): string {
     .replace(/_+/g, '_');
 }
 
-function resetGlobalRegexes(): void {
-  BEARER_REGEX.lastIndex = 0;
-  JWT_REGEX.lastIndex = 0;
-  API_KEY_REGEX.lastIndex = 0;
-  AUTH_HEADER_REGEX.lastIndex = 0;
-  COOKIE_HEADER_REGEX.lastIndex = 0;
+function exactMatchesEntireString(regex: RegExp, value: string): boolean {
+  regex.lastIndex = 0;
+  const match = regex.exec(value);
+  regex.lastIndex = 0;
+  return !!match && match.index === 0 && match[0].length === value.length;
 }
 
 function isLikelyPan(value: string): boolean {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -98,9 +98,30 @@ const DEFAULT_SENSITIVE_KEYS = [
 
 const REDACTION_KEY = 'zeroeval_redaction';
 
+function isResolvedRedactionConfig(
+  config?: Partial<RedactionConfig> | ResolvedRedactionConfig
+): config is ResolvedRedactionConfig {
+  return (
+    !!config &&
+    typeof config.enabled === 'boolean' &&
+    typeof config.redactInputs === 'boolean' &&
+    typeof config.redactOutputs === 'boolean' &&
+    typeof config.redactAttributes === 'boolean' &&
+    typeof config.redactErrors === 'boolean' &&
+    typeof config.redactSessionNames === 'boolean' &&
+    typeof config.redactTagValues === 'boolean' &&
+    Array.isArray(config.sensitiveKeys) &&
+    Array.isArray(config.customPatterns)
+  );
+}
+
 export function resolveRedactionConfig(
-  config?: Partial<RedactionConfig>
+  config?: Partial<RedactionConfig> | ResolvedRedactionConfig
 ): ResolvedRedactionConfig {
+  if (isResolvedRedactionConfig(config)) {
+    return config;
+  }
+
   const enabled = config?.enabled ?? false;
 
   return {
@@ -154,6 +175,38 @@ export function redactOutputValue(
 }
 
 export function redactTextValue(
+  value: string,
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
+): RedactionResult<string> {
+  return redactStringValue(value, config, referenceContext);
+}
+
+export function redactInputTextValue(
+  value: string,
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
+): RedactionResult<string> {
+  if (!config.enabled || !config.redactInputs) {
+    return { value };
+  }
+
+  return redactStringValue(value, config, referenceContext);
+}
+
+export function redactOutputTextValue(
+  value: string,
+  config: ResolvedRedactionConfig,
+  referenceContext?: RedactionReferenceContext
+): RedactionResult<string> {
+  if (!config.enabled || !config.redactOutputs) {
+    return { value };
+  }
+
+  return redactStringValue(value, config, referenceContext);
+}
+
+function redactStringValue(
   value: string,
   config: ResolvedRedactionConfig,
   referenceContext?: RedactionReferenceContext

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -334,7 +334,14 @@ function redactValue(
     if (looksLikeJson(value)) {
       const parsed = tryParseJson(value);
       if (parsed !== undefined) {
-        return redactValue(parsed, config, context);
+        const redacted = redactValue(parsed, config, context);
+        return {
+          value:
+            typeof redacted.value === 'string'
+              ? redacted.value
+              : safeSerialize(redacted.value),
+          metadata: redacted.metadata,
+        };
       }
     }
 
@@ -667,15 +674,14 @@ function createPlaceholder(type: RedactionType, suffix?: string): string {
   return suffix ? `[REDACTED_${type}_${suffix}]` : `[REDACTED_${type}]`;
 }
 
+const DEFAULT_RESOLVED_CONFIG = resolveRedactionConfig({ enabled: true });
+
 function detectRedactionType(value: unknown): RedactionType {
   if (typeof value !== 'string') {
     return 'SECRET';
   }
 
-  const exactType = detectExactMatchType(
-    value,
-    resolveRedactionConfig({ enabled: true })
-  );
+  const exactType = detectExactMatchType(value, DEFAULT_RESOLVED_CONFIG);
   return exactType ?? (value.includes('@') ? 'EMAIL' : 'SECRET');
 }
 

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -554,12 +554,22 @@ function redactString(
     nextValue,
     AUTH_HEADER_REGEX,
     'SECRET',
-    (_match, headerName, separator, headerValue) =>
-      `${headerName}${separator} ${redactSensitiveValueByType(
+    (_match, headerName, separator, headerValue) => {
+      const bearerMatch = headerValue.match(/^Bearer\s+(.+)$/i);
+      if (bearerMatch) {
+        return `${headerName}${separator} Bearer ${redactSensitiveValueByType(
+          'SECRET',
+          bearerMatch[1],
+          referenceContext
+        )}`;
+      }
+
+      return `${headerName}${separator} ${redactSensitiveValueByType(
         'SECRET',
         headerValue,
         referenceContext
-      )}`,
+      )}`;
+    },
     (metadataRef) => {
       metadata = mergeMetadata(metadata, metadataRef);
     },

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -33,6 +33,10 @@ type RedactionResult<T> = {
   metadata?: RedactionMetadata;
 };
 
+type RedactionTraversalContext = {
+  visiting: WeakSet<object>;
+};
+
 type RedactionType = 'EMAIL' | 'PHONE' | 'SSN' | 'PAN' | 'SECRET' | 'IP';
 
 type StringRedactionOptions = {
@@ -118,8 +122,7 @@ export function redactInputValue(
   if (!config.enabled || !config.redactInputs) {
     return { value };
   }
-
-  return redactValue(value, config);
+  return redactValue(value, config, createTraversalContext());
 }
 
 export function redactOutputValue(
@@ -129,8 +132,7 @@ export function redactOutputValue(
   if (!config.enabled || !config.redactOutputs) {
     return { value };
   }
-
-  return redactValue(value, config);
+  return redactValue(value, config, createTraversalContext());
 }
 
 export function redactAttributes(
@@ -140,8 +142,7 @@ export function redactAttributes(
   if (!value || !config.enabled || !config.redactAttributes) {
     return { value };
   }
-
-  return redactObject(value, config);
+  return redactObject(value, config, createTraversalContext());
 }
 
 export function redactTags(
@@ -294,13 +295,14 @@ export function safeSerialize(value: unknown): string {
 
 function redactValue(
   value: unknown,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  context: RedactionTraversalContext
 ): RedactionResult<unknown> {
   if (typeof value === 'string') {
     if (looksLikeJson(value)) {
       const parsed = tryParseJson(value);
       if (parsed !== undefined) {
-        return redactValue(parsed, config);
+        return redactValue(parsed, config, context);
       }
     }
 
@@ -308,11 +310,19 @@ function redactValue(
   }
 
   if (Array.isArray(value)) {
-    return redactArray(value, config);
+    if (context.visiting.has(value)) {
+      return { value: '[Circular]' };
+    }
+
+    return redactArray(value, config, context);
   }
 
   if (value && typeof value === 'object') {
-    return redactObject(value as Record<string, unknown>, config);
+    if (context.visiting.has(value)) {
+      return { value: '[Circular]' };
+    }
+
+    return redactObject(value as Record<string, unknown>, config, context);
   }
 
   return { value };
@@ -320,63 +330,83 @@ function redactValue(
 
 function redactArray(
   value: unknown[],
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  context: RedactionTraversalContext
 ): RedactionResult<unknown[]> {
+  context.visiting.add(value);
+
   let nextValue: unknown[] | undefined;
   let metadata: RedactionMetadata | undefined;
 
-  value.forEach((item, index) => {
-    const redacted = redactValue(item, config);
-    if (!nextValue && redacted.value !== item) {
-      nextValue = [...value];
-    }
+  try {
+    value.forEach((item, index) => {
+      const redacted = redactValue(item, config, context);
+      if (!nextValue && redacted.value !== item) {
+        nextValue = [...value];
+      }
 
-    if (nextValue) {
-      nextValue[index] = redacted.value;
-    }
+      if (nextValue) {
+        nextValue[index] = redacted.value;
+      }
 
-    metadata = mergeMetadata(metadata, redacted.metadata);
-  });
+      metadata = mergeMetadata(metadata, redacted.metadata);
+    });
+  } finally {
+    context.visiting.delete(value);
+  }
 
   return { value: nextValue ?? value, metadata };
 }
 
 function redactObject(
   value: Record<string, unknown>,
-  config: ResolvedRedactionConfig
+  config: ResolvedRedactionConfig,
+  context: RedactionTraversalContext
 ): RedactionResult<Record<string, unknown>> {
+  context.visiting.add(value);
+
   let nextValue: Record<string, unknown> | undefined;
   let metadata: RedactionMetadata | undefined;
 
-  for (const [key, rawValue] of Object.entries(value)) {
-    let redacted: RedactionResult<unknown>;
+  try {
+    for (const [key, rawValue] of Object.entries(value)) {
+      let redacted: RedactionResult<unknown>;
 
-    if (isSensitiveKey(key, config)) {
-      const type = detectRedactionType(rawValue);
-      redacted = {
-        value: createPlaceholder(type, String(rawValue ?? '')),
-        metadata: {
-          enabled: true,
-          count: 1,
-          types: [type],
-        },
-      };
-    } else {
-      redacted = redactValue(rawValue, config);
+      if (isSensitiveKey(key, config)) {
+        const type = detectRedactionType(rawValue);
+        redacted = {
+          value: createPlaceholder(type, String(rawValue ?? '')),
+          metadata: {
+            enabled: true,
+            count: 1,
+            types: [type],
+          },
+        };
+      } else {
+        redacted = redactValue(rawValue, config, context);
+      }
+
+      if (!nextValue && redacted.value !== rawValue) {
+        nextValue = { ...value };
+      }
+
+      if (nextValue) {
+        nextValue[key] = redacted.value;
+      }
+
+      metadata = mergeMetadata(metadata, redacted.metadata);
     }
-
-    if (!nextValue && redacted.value !== rawValue) {
-      nextValue = { ...value };
-    }
-
-    if (nextValue) {
-      nextValue[key] = redacted.value;
-    }
-
-    metadata = mergeMetadata(metadata, redacted.metadata);
+  } finally {
+    context.visiting.delete(value);
   }
 
   return { value: nextValue ?? value, metadata };
+}
+
+function createTraversalContext(): RedactionTraversalContext {
+  return {
+    visiting: new WeakSet<object>(),
+  };
 }
 
 function redactString(

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -609,14 +609,11 @@ function detectRedactionType(value: unknown): RedactionType {
     return 'SECRET';
   }
 
-  return detectExactMatchType(value, resolveRedactionConfig({ enabled: true }))
-    ? (detectExactMatchType(
-        value,
-        resolveRedactionConfig({ enabled: true })
-      ) as RedactionType)
-    : value.includes('@')
-      ? 'EMAIL'
-      : 'SECRET';
+  const exactType = detectExactMatchType(
+    value,
+    resolveRedactionConfig({ enabled: true })
+  );
+  return exactType ?? (value.includes('@') ? 'EMAIL' : 'SECRET');
 }
 
 function detectExactMatchType(

--- a/src/observability/spanDecorator.ts
+++ b/src/observability/spanDecorator.ts
@@ -39,14 +39,8 @@ export function span(
                 // capture args if inputData not provided
                 if (opts.inputData === undefined) {
                   const output =
-                    opts.outputData !== undefined
-                      ? typeof opts.outputData === 'string'
-                        ? opts.outputData
-                        : JSON.stringify(opts.outputData, replacer, 2)
-                      : typeof r === 'string'
-                        ? r
-                        : JSON.stringify(r, replacer, 2);
-                  spanInst.setIO(JSON.stringify(args, replacer, 2), output);
+                    opts.outputData !== undefined ? opts.outputData : r;
+                  spanInst.setIO(args, output);
                 } else {
                   const output =
                     opts.outputData !== undefined ? opts.outputData : r;
@@ -68,14 +62,8 @@ export function span(
           // sync path
           if (opts.inputData === undefined) {
             const output =
-              opts.outputData !== undefined
-                ? typeof opts.outputData === 'string'
-                  ? opts.outputData
-                  : JSON.stringify(opts.outputData, replacer, 2)
-                : typeof result === 'string'
-                  ? result
-                  : JSON.stringify(result, replacer, 2);
-            spanInst.setIO(JSON.stringify(args, replacer, 2), output);
+              opts.outputData !== undefined ? opts.outputData : result;
+            spanInst.setIO(args, output);
           } else {
             const output =
               opts.outputData !== undefined ? opts.outputData : result;
@@ -150,12 +138,4 @@ export function withSpan<T>(
     tracer.endSpan(spanInst);
     throw err;
   }
-}
-
-// util replacer to avoid circular
-function replacer(_key: string, value: unknown) {
-  if (typeof value === 'bigint') return value.toString();
-  if (typeof value === 'function')
-    return `[Function ${value.name || 'anonymous'}]`;
-  return value;
 }

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -155,13 +155,13 @@ export class BackendSpanWriter implements SpanWriter {
       traceIds.add(base.trace_id);
       if (base.session_id) sessionIds.add(base.session_id);
       const lookupId =
-        typeof s?.sessionLookupId === 'string' ? s.sessionLookupId : undefined;
+        typeof s?._sessionLookupId === 'string' ? s._sessionLookupId : undefined;
       if (lookupId && sessionId.value) {
         sessionLookupToRedacted.set(lookupId, sessionId.value);
       }
 
-      // Extract kind from attributes (default to 'generic')
-      const kind = base.attributes?.kind ?? 'generic';
+      // Extract kind from redacted attributes (default to 'generic')
+      const kind = mergedAttributes.kind ?? 'generic';
 
       return {
         id: base.span_id,

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -4,6 +4,7 @@ import { getLogger, Logger } from './logger';
 import { getApiUrl, getApiKey } from '../utils/api';
 import {
   attachRedactionMetadata,
+  createRedactionReferenceContext,
   redactAttributes,
   redactErrorInfo,
   redactInputValue,
@@ -14,7 +15,11 @@ import {
   resolveRedactionConfig,
   safeSerialize,
 } from './redaction';
-import type { RedactionConfig, ResolvedRedactionConfig } from './redaction';
+import type {
+  RedactionConfig,
+  RedactionReferenceContext,
+  ResolvedRedactionConfig,
+} from './redaction';
 
 const logger = getLogger('zeroeval.writer');
 
@@ -51,20 +56,48 @@ export class BackendSpanWriter implements SpanWriter {
     }> = [];
     const traceIds = new Set<string>();
     const sessionIds = new Set<string>();
+    const traceReferenceContexts = new Map<string, RedactionReferenceContext>();
 
     const payload = spans.map((s: any) => {
       const base = typeof s.toJSON === 'function' ? s.toJSON() : s;
+      const referenceContext =
+        typeof s?.getRedactionReferenceContext === 'function'
+          ? s.getRedactionReferenceContext()
+          : undefined;
+      const traceReferenceContext =
+        referenceContext ??
+        traceReferenceContexts.get(base.trace_id) ??
+        createRedactionReferenceContext();
+      traceReferenceContexts.set(base.trace_id, traceReferenceContext);
       const attributes = redactAttributes(
         base.attributes,
-        this.redactionConfig
+        this.redactionConfig,
+        traceReferenceContext
       );
-      const tags = redactTags(base.tags, this.redactionConfig);
-      const traceTags = redactTags(base.trace_tags, this.redactionConfig);
-      const sessionTags = redactTags(base.session_tags, this.redactionConfig);
-      const inputData = redactInputValue(base.input_data, this.redactionConfig);
+      const tags = redactTags(
+        base.tags,
+        this.redactionConfig,
+        traceReferenceContext
+      );
+      const traceTags = redactTags(
+        base.trace_tags,
+        this.redactionConfig,
+        traceReferenceContext
+      );
+      const sessionTags = redactTags(
+        base.session_tags,
+        this.redactionConfig,
+        traceReferenceContext
+      );
+      const inputData = redactInputValue(
+        base.input_data,
+        this.redactionConfig,
+        traceReferenceContext
+      );
       const outputData = redactOutputValue(
         base.output_data,
-        this.redactionConfig
+        this.redactionConfig,
+        traceReferenceContext
       );
       const errorInfo = redactErrorInfo(
         {
@@ -72,15 +105,18 @@ export class BackendSpanWriter implements SpanWriter {
           message: base.error_message,
           stack: base.error_stack,
         },
-        this.redactionConfig
+        this.redactionConfig,
+        traceReferenceContext
       );
       const sessionName = redactSessionName(
         base.session_name,
-        this.redactionConfig
+        this.redactionConfig,
+        traceReferenceContext
       );
       const sessionId = redactSessionIdentifier(
         base.session_id,
-        this.redactionConfig
+        this.redactionConfig,
+        traceReferenceContext
       );
       const mergedAttributes = {
         ...(attributes.value ?? {}),

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -9,6 +9,7 @@ import {
   redactErrorInfo,
   redactInputValue,
   redactOutputValue,
+  redactTextValue,
   redactSessionIdentifier,
   redactSessionName,
   redactTags,
@@ -89,16 +90,30 @@ export class BackendSpanWriter implements SpanWriter {
         this.redactionConfig,
         traceReferenceContext
       );
-      const inputData = redactInputValue(
-        base.input_data,
-        this.redactionConfig,
-        traceReferenceContext
-      );
-      const outputData = redactOutputValue(
-        base.output_data,
-        this.redactionConfig,
-        traceReferenceContext
-      );
+      const inputData =
+        typeof base.input_data === 'string'
+          ? redactTextValue(
+              base.input_data,
+              this.redactionConfig,
+              traceReferenceContext
+            )
+          : redactInputValue(
+              base.input_data,
+              this.redactionConfig,
+              traceReferenceContext
+            );
+      const outputData =
+        typeof base.output_data === 'string'
+          ? redactTextValue(
+              base.output_data,
+              this.redactionConfig,
+              traceReferenceContext
+            )
+          : redactOutputValue(
+              base.output_data,
+              this.redactionConfig,
+              traceReferenceContext
+            );
       const errorInfo = redactErrorInfo(
         {
           code: base.error_code,

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -58,6 +58,7 @@ export class BackendSpanWriter implements SpanWriter {
     }> = [];
     const traceIds = new Set<string>();
     const sessionIds = new Set<string>();
+    const sessionLookupIds = new Set<string>();
     const traceReferenceContexts = new Map<string, RedactionReferenceContext>();
 
     const payload = spans.map((s: any) => {
@@ -153,6 +154,9 @@ export class BackendSpanWriter implements SpanWriter {
       }
       traceIds.add(base.trace_id);
       if (base.session_id) sessionIds.add(base.session_id);
+      const lookupId =
+        typeof s?.sessionLookupId === 'string' ? s.sessionLookupId : undefined;
+      if (lookupId) sessionLookupIds.add(lookupId);
 
       // Extract kind from attributes (default to 'generic')
       const kind = base.attributes?.kind ?? 'generic';
@@ -242,7 +246,8 @@ export class BackendSpanWriter implements SpanWriter {
         // After spans persisted, send buffered trace/session signals
         await this.flushTraceSessionSignals(
           Array.from(traceIds),
-          Array.from(sessionIds)
+          Array.from(sessionIds),
+          Array.from(sessionLookupIds)
         );
       }
     } catch (err) {
@@ -295,7 +300,8 @@ export class BackendSpanWriter implements SpanWriter {
 
   private async flushTraceSessionSignals(
     traceIds: string[],
-    sessionIds: string[]
+    sessionIds: string[],
+    sessionLookupIds: string[]
   ): Promise<void> {
     if (traceIds.length === 0 && sessionIds.length === 0) return;
 
@@ -319,7 +325,8 @@ export class BackendSpanWriter implements SpanWriter {
       }
     }
 
-    for (const sid of sessionIds) {
+    const lookupIds = new Set([...sessionIds, ...sessionLookupIds]);
+    for (const sid of lookupIds) {
       const signals = popPendingSessionSignals(sid);
       if (!signals) continue;
       for (const [name, sig] of Object.entries(signals)) {

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -12,6 +12,7 @@ import {
   redactSessionName,
   redactTags,
   resolveRedactionConfig,
+  safeSerialize,
 } from './redaction';
 import type { RedactionConfig, ResolvedRedactionConfig } from './redaction';
 
@@ -117,8 +118,14 @@ export class BackendSpanWriter implements SpanWriter {
         duration_ms: base.duration_ms,
         attributes: mergedAttributes,
         status: base.status,
-        input_data: inputData.value,
-        output_data: outputData.value,
+        input_data:
+          typeof inputData.value === 'string'
+            ? inputData.value
+            : safeSerialize(inputData.value),
+        output_data:
+          typeof outputData.value === 'string'
+            ? outputData.value
+            : safeSerialize(outputData.value),
         code: base.code ?? base.attributes?.code,
         code_filepath: base.code_filepath ?? base.attributes?.code_filepath,
         code_lineno: base.code_lineno ?? base.attributes?.code_lineno,

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -2,6 +2,18 @@ import { signalWriter } from './signalWriter';
 import type { Signal, SignalCreate } from './signals';
 import { getLogger, Logger } from './logger';
 import { getApiUrl, getApiKey } from '../utils/api';
+import {
+  attachRedactionMetadata,
+  redactAttributes,
+  redactErrorInfo,
+  redactInputValue,
+  redactOutputValue,
+  redactSessionIdentifier,
+  redactSessionName,
+  redactTags,
+  resolveRedactionConfig,
+} from './redaction';
+import type { RedactionConfig, ResolvedRedactionConfig } from './redaction';
 
 const logger = getLogger('zeroeval.writer');
 
@@ -15,6 +27,12 @@ export interface SpanWriter {
 }
 
 export class BackendSpanWriter implements SpanWriter {
+  private redactionConfig: ResolvedRedactionConfig = resolveRedactionConfig();
+
+  setRedactionConfig(config?: Partial<RedactionConfig>): void {
+    this.redactionConfig = resolveRedactionConfig(config);
+  }
+
   async write(spans: any[]): Promise<void> {
     if (!spans.length) return;
 
@@ -35,6 +53,47 @@ export class BackendSpanWriter implements SpanWriter {
 
     const payload = spans.map((s: any) => {
       const base = typeof s.toJSON === 'function' ? s.toJSON() : s;
+      const attributes = redactAttributes(
+        base.attributes,
+        this.redactionConfig
+      );
+      const tags = redactTags(base.tags, this.redactionConfig);
+      const traceTags = redactTags(base.trace_tags, this.redactionConfig);
+      const sessionTags = redactTags(base.session_tags, this.redactionConfig);
+      const inputData = redactInputValue(base.input_data, this.redactionConfig);
+      const outputData = redactOutputValue(
+        base.output_data,
+        this.redactionConfig
+      );
+      const errorInfo = redactErrorInfo(
+        {
+          code: base.error_code,
+          message: base.error_message,
+          stack: base.error_stack,
+        },
+        this.redactionConfig
+      );
+      const sessionName = redactSessionName(
+        base.session_name,
+        this.redactionConfig
+      );
+      const sessionId = redactSessionIdentifier(
+        base.session_id,
+        this.redactionConfig
+      );
+      const mergedAttributes = {
+        ...(attributes.value ?? {}),
+      };
+
+      attachRedactionMetadata(mergedAttributes, attributes.metadata);
+      attachRedactionMetadata(mergedAttributes, tags.metadata);
+      attachRedactionMetadata(mergedAttributes, traceTags.metadata);
+      attachRedactionMetadata(mergedAttributes, sessionTags.metadata);
+      attachRedactionMetadata(mergedAttributes, inputData.metadata);
+      attachRedactionMetadata(mergedAttributes, outputData.metadata);
+      attachRedactionMetadata(mergedAttributes, errorInfo.metadata);
+      attachRedactionMetadata(mergedAttributes, sessionName.metadata);
+      attachRedactionMetadata(mergedAttributes, sessionId.metadata);
 
       if (base.signals && Object.keys(base.signals).length > 0) {
         spansWithSignals.push({ spanId: base.span_id, signals: base.signals });
@@ -47,8 +106,8 @@ export class BackendSpanWriter implements SpanWriter {
 
       return {
         id: base.span_id,
-        session_id: base.session_id,
-        session_name: base.session_name,
+        session_id: sessionId.value,
+        session_name: sessionName.value,
         trace_id: base.trace_id,
         parent_span_id: base.parent_id,
         name: base.name,
@@ -56,19 +115,19 @@ export class BackendSpanWriter implements SpanWriter {
         started_at: base.start_time,
         ended_at: base.end_time,
         duration_ms: base.duration_ms,
-        attributes: base.attributes,
+        attributes: mergedAttributes,
         status: base.status,
-        input_data: base.input_data,
-        output_data: base.output_data,
+        input_data: inputData.value,
+        output_data: outputData.value,
         code: base.code ?? base.attributes?.code,
         code_filepath: base.code_filepath ?? base.attributes?.code_filepath,
         code_lineno: base.code_lineno ?? base.attributes?.code_lineno,
-        error_code: base.error_code,
-        error_message: base.error_message,
-        error_stack: String(base.error_stack ?? ''),
-        tags: base.tags,
-        trace_tags: base.trace_tags,
-        session_tags: base.session_tags,
+        error_code: errorInfo.value?.code,
+        error_message: errorInfo.value?.message,
+        error_stack: String(errorInfo.value?.stack ?? ''),
+        tags: tags.value,
+        trace_tags: traceTags.value,
+        session_tags: sessionTags.value,
       };
     });
 

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -58,7 +58,7 @@ export class BackendSpanWriter implements SpanWriter {
     }> = [];
     const traceIds = new Set<string>();
     const sessionIds = new Set<string>();
-    const sessionLookupIds = new Set<string>();
+    const sessionLookupToRedacted = new Map<string, string>();
     const traceReferenceContexts = new Map<string, RedactionReferenceContext>();
 
     const payload = spans.map((s: any) => {
@@ -156,7 +156,9 @@ export class BackendSpanWriter implements SpanWriter {
       if (base.session_id) sessionIds.add(base.session_id);
       const lookupId =
         typeof s?.sessionLookupId === 'string' ? s.sessionLookupId : undefined;
-      if (lookupId) sessionLookupIds.add(lookupId);
+      if (lookupId && sessionId.value) {
+        sessionLookupToRedacted.set(lookupId, sessionId.value);
+      }
 
       // Extract kind from attributes (default to 'generic')
       const kind = base.attributes?.kind ?? 'generic';
@@ -247,7 +249,7 @@ export class BackendSpanWriter implements SpanWriter {
         await this.flushTraceSessionSignals(
           Array.from(traceIds),
           Array.from(sessionIds),
-          Array.from(sessionLookupIds)
+          sessionLookupToRedacted
         );
       }
     } catch (err) {
@@ -301,7 +303,7 @@ export class BackendSpanWriter implements SpanWriter {
   private async flushTraceSessionSignals(
     traceIds: string[],
     sessionIds: string[],
-    sessionLookupIds: string[]
+    sessionLookupToRedacted: Map<string, string>
   ): Promise<void> {
     if (traceIds.length === 0 && sessionIds.length === 0) return;
 
@@ -325,7 +327,23 @@ export class BackendSpanWriter implements SpanWriter {
       }
     }
 
-    const lookupIds = new Set([...sessionIds, ...sessionLookupIds]);
+    const lookupIds = new Set<string>(sessionIds);
+    for (const [rawId, redactedId] of sessionLookupToRedacted) {
+      if (!lookupIds.has(redactedId)) {
+        lookupIds.add(redactedId);
+      }
+      const signals = popPendingSessionSignals(rawId);
+      if (!signals) continue;
+      for (const [name, sig] of Object.entries(signals)) {
+        bulk.push({
+          entity_type: 'session',
+          entity_id: redactedId,
+          name,
+          value: sig.value,
+          signal_type: sig.type,
+        });
+      }
+    }
     for (const sid of lookupIds) {
       const signals = popPendingSessionSignals(sid);
       if (!signals) continue;

--- a/src/observability/writer.ts
+++ b/src/observability/writer.ts
@@ -7,9 +7,10 @@ import {
   createRedactionReferenceContext,
   redactAttributes,
   redactErrorInfo,
+  redactInputTextValue,
   redactInputValue,
+  redactOutputTextValue,
   redactOutputValue,
-  redactTextValue,
   redactSessionIdentifier,
   redactSessionName,
   redactTags,
@@ -92,7 +93,7 @@ export class BackendSpanWriter implements SpanWriter {
       );
       const inputData =
         typeof base.input_data === 'string'
-          ? redactTextValue(
+          ? redactInputTextValue(
               base.input_data,
               this.redactionConfig,
               traceReferenceContext
@@ -104,7 +105,7 @@ export class BackendSpanWriter implements SpanWriter {
             );
       const outputData =
         typeof base.output_data === 'string'
-          ? redactTextValue(
+          ? redactOutputTextValue(
               base.output_data,
               this.redactionConfig,
               traceReferenceContext

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -176,11 +176,11 @@ describe('Span Decorator', () => {
       expect(mockWriter.spans).toHaveLength(1);
 
       const s = mockWriter.spans[0];
-      expect(s.input_data).toContain('[REDACTED_EMAIL]');
-      expect(s.input_data).toContain('[REDACTED_SECRET]');
+      expect(s.input_data).toContain('[REDACTED_EMAIL_A]');
+      expect(s.input_data).toContain('[REDACTED_SECRET_A]');
       expect(s.input_data).not.toContain('alice@example.com');
-      expect(s.output_data).toContain('[REDACTED_PHONE]');
-      expect(s.output_data).toContain('[REDACTED_EMAIL]');
+      expect(s.output_data).toContain('[REDACTED_PHONE_A]');
+      expect(s.output_data).toContain('[REDACTED_EMAIL_A]');
       expect(s.attributes.zeroeval_redaction.enabled).toBe(true);
     });
 

--- a/tests/core/decorator.test.ts
+++ b/tests/core/decorator.test.ts
@@ -12,11 +12,17 @@ describe('Span Decorator', () => {
     mockWriter = new MockSpanWriter();
     (tracer as any)._writer = mockWriter;
     (tracer as any)._shuttingDown = false;
+    tracer.configure({
+      redaction: { enabled: false },
+    });
   });
 
   afterEach(() => {
     // Clean up
     (tracer as any).flush();
+    tracer.configure({
+      redaction: { enabled: false },
+    });
     mockWriter.clear();
   });
 
@@ -144,6 +150,38 @@ describe('Span Decorator', () => {
       const s = mockWriter.spans[0];
       expect(s.input_data).toBe('custom input');
       expect(s.output_data).toBe('custom output');
+    });
+
+    it('should redact decorator-captured inputs and outputs when enabled', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      class TestClass {
+        @span({ name: 'redacted_method' })
+        process(payload: { email: string; authorization: string }): string {
+          return `Call +1 (415) 555-1212 for ${payload.email}`;
+        }
+      }
+
+      const instance = new TestClass();
+      const result = instance.process({
+        email: 'alice@example.com',
+        authorization: 'Bearer super-secret-token',
+      });
+
+      tracer.flush();
+
+      expect(result).toContain('alice@example.com');
+      expect(mockWriter.spans).toHaveLength(1);
+
+      const s = mockWriter.spans[0];
+      expect(s.input_data).toContain('[REDACTED_EMAIL]');
+      expect(s.input_data).toContain('[REDACTED_SECRET]');
+      expect(s.input_data).not.toContain('alice@example.com');
+      expect(s.output_data).toContain('[REDACTED_PHONE]');
+      expect(s.output_data).toContain('[REDACTED_EMAIL]');
+      expect(s.attributes.zeroeval_redaction.enabled).toBe(true);
     });
 
     it('should handle nested decorated functions', () => {

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -272,4 +272,47 @@ describe('PII redaction', () => {
     expect(requestBodies[0]).toContain('[REDACTED_SECRET_A]');
     expect(requestBodies[0]).not.toContain('alice@example.com');
   });
+
+  it('should reuse identical authorization and cookie header values and separate different ones', () => {
+    const span = new Span('header-redaction', undefined, {
+      enabled: true,
+    });
+
+    span.setIO(
+      [
+        'Authorization: Bearer shared-token',
+        'authorization: Bearer shared-token',
+        'Cookie: session=abc123',
+        'cookie: session=abc123',
+        'Authorization: Bearer other-token',
+        'Cookie: session=xyz999',
+      ].join('\n'),
+      undefined
+    );
+
+    const json = span.toJSON();
+    const secretTokens = Array.from(
+      json.input_data.matchAll(
+        /(Authorization|authorization|Cookie|cookie): (\[REDACTED_SECRET_[A-Z]+\])/g
+      )
+    ).map((match) => ({
+      name: match[1],
+      token: match[2],
+    }));
+
+    expect(secretTokens).toEqual([
+      { name: 'Authorization', token: expect.any(String) },
+      { name: 'authorization', token: expect.any(String) },
+      { name: 'Cookie', token: expect.any(String) },
+      { name: 'cookie', token: expect.any(String) },
+      { name: 'Authorization', token: expect.any(String) },
+      { name: 'Cookie', token: expect.any(String) },
+    ]);
+    expect(secretTokens[0].token).toBe(secretTokens[1].token);
+    expect(secretTokens[2].token).toBe(secretTokens[3].token);
+    expect(secretTokens[0].token).not.toBe(secretTokens[4].token);
+    expect(secretTokens[2].token).not.toBe(secretTokens[5].token);
+    expect(json.input_data).not.toContain('shared-token');
+    expect(json.input_data).not.toContain('abc123');
+  });
 });

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -7,6 +7,7 @@ import { BackendSpanWriter } from '../../src/observability/writer';
 import {
   createRedactionReferenceContext,
   redactAttributes,
+  redactSessionIdentifier,
   resolveRedactionConfig,
 } from '../../src/observability/redaction';
 import { MockSpanWriter } from '../setup';
@@ -324,6 +325,54 @@ describe('PII redaction', () => {
     expect(payload[0].output_data).not.toContain('shared-token');
   });
 
+  it('should redact sensitive keys inside JSON string payloads in writer fail-safe redaction', async () => {
+    const writer = new BackendSpanWriter();
+    writer.setRedactionConfig({ enabled: true });
+
+    const requestBodies: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url, init) => {
+      requestBodies.push(String(init?.body ?? ''));
+      return {
+        ok: true,
+        status: 200,
+        text: async () => 'ok',
+        headers: { forEach: () => undefined },
+      } as Response;
+    });
+
+    await writer.write([
+      {
+        span_id: 'span-json-keys',
+        trace_id: 'trace-json-keys',
+        name: 'writer-json-key-redaction',
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        duration_ms: 1,
+        status: 'ok',
+        attributes: {},
+        input_data:
+          '{"password":"hunter2","apiKey":"not-a-real-key","nested":{"confirmEmail":"alice@example.com"}}',
+        output_data:
+          '{"refreshToken":"refresh-placeholder","clientSecret":"client-placeholder"}',
+        tags: {},
+        trace_tags: {},
+        session_tags: {},
+      },
+    ]);
+
+    const payload = JSON.parse(requestBodies[0]);
+
+    expect(typeof payload[0].input_data).toBe('string');
+    expect(typeof payload[0].output_data).toBe('string');
+    expect(payload[0].input_data).toContain('[REDACTED_SECRET_');
+    expect(payload[0].input_data).toContain('[REDACTED_EMAIL_');
+    expect(payload[0].input_data).not.toContain('hunter2');
+    expect(payload[0].input_data).not.toContain('alice@example.com');
+    expect(payload[0].output_data).toContain('[REDACTED_SECRET_');
+    expect(payload[0].output_data).not.toContain('refresh-placeholder');
+    expect(payload[0].output_data).not.toContain('client-placeholder');
+  });
+
   it('should respect per-field redaction flags in writer fail-safe redaction', async () => {
     const writer = new BackendSpanWriter();
     writer.setRedactionConfig({
@@ -425,6 +474,26 @@ describe('PII redaction', () => {
     );
     expect(resolved.customPatterns[0]).toBeInstanceOf(RegExp);
     expect(resolved.customPatterns[0].source).toContain('secret-value');
+  });
+
+  it('should only exact-match secret and custom patterns for session identifiers', () => {
+    const config = resolveRedactionConfig({
+      enabled: true,
+      customPatterns: [/secret-token/g],
+    });
+
+    expect(
+      redactSessionIdentifier('prefix Bearer shared-token', config).value
+    ).toBe('prefix Bearer shared-token');
+    expect(
+      redactSessionIdentifier('prefix secret-token suffix', config).value
+    ).toBe('prefix secret-token suffix');
+    expect(redactSessionIdentifier('Bearer shared-token', config).value).toBe(
+      '[REDACTED_SECRET]'
+    );
+    expect(redactSessionIdentifier('secret-token', config).value).toBe(
+      '[REDACTED_SECRET]'
+    );
   });
 
   it('should reuse identical authorization and cookie header values and separate different ones', () => {

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -516,7 +516,7 @@ describe('PII redaction', () => {
     const json = span.toJSON();
     const secretTokens = Array.from(
       json.input_data.matchAll(
-        /(Authorization|authorization|Cookie|cookie): (\[REDACTED_SECRET_[A-Z]+\])/g
+        /(Authorization|authorization|Cookie|cookie): (?:Bearer )?(\[REDACTED_SECRET_[A-Z]+\])/g
       )
     ).map((match) => ({
       name: match[1],
@@ -537,5 +537,29 @@ describe('PII redaction', () => {
     expect(secretTokens[2].token).not.toBe(secretTokens[5].token);
     expect(json.input_data).not.toContain('shared-token');
     expect(json.input_data).not.toContain('abc123');
+  });
+
+  it('should reuse the same placeholder for bearer tokens in standalone text and authorization headers', () => {
+    const span = new Span('bearer-consistency', undefined, {
+      enabled: true,
+    });
+
+    span.setIO(
+      [
+        'Bearer shared-token',
+        'Authorization: Bearer shared-token',
+        'Proxy-Authorization: Bearer shared-token',
+      ].join('\n'),
+      undefined
+    );
+
+    const json = span.toJSON();
+    const tokens = Array.from(
+      json.input_data.matchAll(/\[REDACTED_SECRET_[A-Z]+\]/g)
+    ).map((match) => match[0]);
+
+    expect(tokens).toHaveLength(3);
+    expect(new Set(tokens).size).toBe(1);
+    expect(json.input_data).not.toContain('shared-token');
   });
 });

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -4,6 +4,11 @@ import { Span } from '../../src/observability/Span';
 import { tracer } from '../../src/observability/Tracer';
 import { Logger } from '../../src/observability/logger';
 import { BackendSpanWriter } from '../../src/observability/writer';
+import {
+  createRedactionReferenceContext,
+  redactAttributes,
+  resolveRedactionConfig,
+} from '../../src/observability/redaction';
 import { MockSpanWriter } from '../setup';
 
 describe('PII redaction', () => {
@@ -271,6 +276,65 @@ describe('PII redaction', () => {
     expect(requestBodies[0]).toContain('[REDACTED_EMAIL_A]');
     expect(requestBodies[0]).toContain('[REDACTED_SECRET_A]');
     expect(requestBodies[0]).not.toContain('alice@example.com');
+  });
+
+  it('should preserve string-typed wire format for JSON-looking payload strings in writer fail-safe redaction', async () => {
+    const writer = new BackendSpanWriter();
+    writer.setRedactionConfig({ enabled: true });
+
+    const requestBodies: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url, init) => {
+      requestBodies.push(String(init?.body ?? ''));
+      return {
+        ok: true,
+        status: 200,
+        text: async () => 'ok',
+        headers: { forEach: () => undefined },
+      } as Response;
+    });
+
+    await writer.write([
+      {
+        span_id: 'span-3',
+        trace_id: 'trace-3',
+        name: 'writer-string-wire-format',
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        duration_ms: 1,
+        status: 'ok',
+        attributes: {},
+        input_data:
+          '{"email":"alice@example.com","known":"[REDACTED_EMAIL_A]"}',
+        output_data:
+          '{"token":"Bearer shared-token","known":"[REDACTED_SECRET_A]"}',
+        tags: {},
+        trace_tags: {},
+        session_tags: {},
+      },
+    ]);
+
+    expect(requestBodies).toHaveLength(1);
+    const payload = JSON.parse(requestBodies[0]);
+
+    expect(typeof payload[0].input_data).toBe('string');
+    expect(typeof payload[0].output_data).toBe('string');
+    expect(payload[0].input_data).toContain('[REDACTED_EMAIL_A]');
+    expect(payload[0].output_data).toContain('[REDACTED_SECRET_A]');
+    expect(payload[0].input_data).not.toContain('alice@example.com');
+    expect(payload[0].output_data).not.toContain('shared-token');
+  });
+
+  it('should not inflate metadata for already-redacted sensitive-key object values', () => {
+    const config = resolveRedactionConfig({ enabled: true });
+    const referenceContext = createRedactionReferenceContext();
+    const attributes = {
+      authorization: '[REDACTED_SECRET_A]',
+    };
+
+    const redacted = redactAttributes(attributes, config, referenceContext);
+
+    expect(redacted.value).toBe(attributes);
+    expect(redacted.metadata).toBeUndefined();
   });
 
   it('should reuse identical authorization and cookie header values and separate different ones', () => {

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -324,6 +324,49 @@ describe('PII redaction', () => {
     expect(payload[0].output_data).not.toContain('shared-token');
   });
 
+  it('should respect per-field redaction flags in writer fail-safe redaction', async () => {
+    const writer = new BackendSpanWriter();
+    writer.setRedactionConfig({
+      enabled: true,
+      redactInputs: false,
+      redactOutputs: true,
+    });
+
+    const requestBodies: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url, init) => {
+      requestBodies.push(String(init?.body ?? ''));
+      return {
+        ok: true,
+        status: 200,
+        text: async () => 'ok',
+        headers: { forEach: () => undefined },
+      } as Response;
+    });
+
+    await writer.write([
+      {
+        span_id: 'span-4',
+        trace_id: 'trace-4',
+        name: 'writer-redaction-flags',
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        duration_ms: 1,
+        status: 'ok',
+        attributes: {},
+        input_data: 'alice@example.com',
+        output_data: 'alice@example.com',
+        tags: {},
+        trace_tags: {},
+        session_tags: {},
+      },
+    ]);
+
+    const payload = JSON.parse(requestBodies[0]);
+
+    expect(payload[0].input_data).toBe('alice@example.com');
+    expect(payload[0].output_data).toContain('[REDACTED_EMAIL_A]');
+  });
+
   it('should not inflate metadata for already-redacted sensitive-key object values', () => {
     const config = resolveRedactionConfig({ enabled: true });
     const referenceContext = createRedactionReferenceContext();

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -53,16 +53,57 @@ describe('PII redaction', () => {
 
     const json = span.toJSON();
 
-    expect(json.input_data).toContain('[REDACTED_EMAIL]');
-    expect(json.input_data).toContain('[REDACTED_PHONE]');
-    expect(json.input_data).toContain('[REDACTED_PAN]');
-    expect(json.input_data).toContain('[REDACTED_SECRET]');
-    expect(json.output_data).toContain('[REDACTED_EMAIL]');
-    expect(json.output_data).toContain('[REDACTED_IP]');
-    expect(json.error_message).toContain('[REDACTED_SECRET]');
+    expect(json.input_data).toContain('[REDACTED_EMAIL_A]');
+    expect(json.input_data).toContain('[REDACTED_PHONE_A]');
+    expect(json.input_data).toContain('[REDACTED_PAN_A]');
+    expect(json.input_data).toContain('[REDACTED_SECRET_A]');
+    expect(json.output_data).toContain('[REDACTED_EMAIL_A]');
+    expect(json.output_data).toContain('[REDACTED_IP_A]');
+    expect(json.error_message).toContain('[REDACTED_SECRET_B]');
     expect(json.error_message).not.toContain('alice@example.com');
     expect(json.error_message).not.toContain('123-45-6789');
     expect(json.attributes).toHaveProperty('zeroeval_redaction');
+  });
+
+  it('should preserve references for repeated exact sensitive values within one span', () => {
+    const mockWriter = new MockSpanWriter();
+    (tracer as any)._writer = mockWriter;
+    (tracer as any)._shuttingDown = false;
+    tracer.configure({
+      redaction: { enabled: true },
+    });
+
+    const repeatedEmail = 'seb@zeroeval.com';
+    const span = tracer.startSpan('reference-span', {
+      attributes: {
+        email: repeatedEmail,
+      },
+      tags: {
+        support_email: repeatedEmail,
+      },
+    });
+
+    span.setIO(
+      `input ${repeatedEmail}`,
+      `output ${repeatedEmail} and other@example.com`
+    );
+    span.setError({
+      message: `error ${repeatedEmail}`,
+    });
+    tracer.endSpan(span);
+    void tracer.flush();
+
+    const payload = mockWriter.spans[0];
+    const serialized = JSON.stringify(payload);
+
+    expect(serialized).toContain('[REDACTED_EMAIL_A]');
+    expect(serialized).toContain('[REDACTED_EMAIL_B]');
+    expect(serialized.match(/\[REDACTED_EMAIL_A\]/g)?.length).toBeGreaterThan(
+      3
+    );
+    expect(payload.attributes.email).toBe('[REDACTED_EMAIL_A]');
+    expect(payload.tags.support_email).toBe('[REDACTED_EMAIL_A]');
+    expect(payload.output_data).toContain('[REDACTED_EMAIL_B]');
   });
 
   it('should preserve existing behavior when redaction is disabled', () => {
@@ -92,8 +133,8 @@ describe('PII redaction', () => {
 
     const json = span.toJSON();
 
-    expect(json.input_data).toContain('[REDACTED_PHONE]');
-    expect(json.output_data).toContain('[REDACTED_SECRET]');
+    expect(json.input_data).toContain('[REDACTED_PHONE_A]');
+    expect(json.output_data).toContain('[REDACTED_SECRET_A]');
   });
 
   it('should handle circular payloads without throwing and keep output serializable', () => {
@@ -109,9 +150,9 @@ describe('PII redaction', () => {
 
     const json = span.toJSON();
 
-    expect(json.input_data).toContain('[REDACTED_EMAIL]');
+    expect(json.input_data).toContain('[REDACTED_EMAIL_A]');
     expect(json.input_data).toContain('[Circular]');
-    expect(json.output_data).toContain('[REDACTED_EMAIL]');
+    expect(json.output_data).toContain('[REDACTED_EMAIL_A]');
     expect(json.output_data).toContain('[Circular]');
   });
 
@@ -129,8 +170,8 @@ describe('PII redaction', () => {
     await tracer.flush();
 
     expect(mockWriter.spans).toHaveLength(1);
-    expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL]');
-    expect(mockWriter.spans[0].output_data).toContain('[REDACTED_SECRET]');
+    expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL_A]');
+    expect(mockWriter.spans[0].output_data).toContain('[REDACTED_SECRET_A]');
   });
 
   it('should redact writer debug logs before logging or sending spans', async () => {
@@ -178,8 +219,8 @@ describe('PII redaction', () => {
     ]);
 
     expect(requestBodies).toHaveLength(1);
-    expect(requestBodies[0]).toContain('[REDACTED_EMAIL]');
-    expect(requestBodies[0]).toContain('[REDACTED_PAN]');
+    expect(requestBodies[0]).toContain('[REDACTED_EMAIL_A]');
+    expect(requestBodies[0]).toContain('[REDACTED_PAN_A]');
     expect(requestBodies[0]).not.toContain('alice@example.com');
     expect(requestBodies[0]).not.toContain('4111 1111 1111 1111');
 
@@ -188,8 +229,47 @@ describe('PII redaction', () => {
       .map((item) => String(item))
       .join('\n');
 
-    expect(combinedLogs).toContain('[REDACTED_EMAIL]');
+    expect(combinedLogs).toContain('[REDACTED_EMAIL_A]');
     expect(combinedLogs).not.toContain('alice@example.com');
     expect(combinedLogs).not.toContain('live-token');
+  });
+
+  it('should preserve existing placeholders during writer fail-safe redaction', async () => {
+    const writer = new BackendSpanWriter();
+    writer.setRedactionConfig({ enabled: true });
+
+    const requestBodies: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url, init) => {
+      requestBodies.push(String(init?.body ?? ''));
+      return {
+        ok: true,
+        status: 200,
+        text: async () => 'ok',
+        headers: { forEach: () => undefined },
+      } as Response;
+    });
+
+    await writer.write([
+      {
+        span_id: 'span-2',
+        trace_id: 'trace-2',
+        name: 'writer-placeholder-preservation',
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        duration_ms: 1,
+        status: 'ok',
+        attributes: {},
+        input_data: 'Known [REDACTED_EMAIL_A] plus alice@example.com',
+        output_data: '[REDACTED_SECRET_A]',
+        tags: {},
+        trace_tags: {},
+        session_tags: {},
+      },
+    ]);
+
+    expect(requestBodies).toHaveLength(1);
+    expect(requestBodies[0]).toContain('[REDACTED_EMAIL_A]');
+    expect(requestBodies[0]).toContain('[REDACTED_SECRET_A]');
+    expect(requestBodies[0]).not.toContain('alice@example.com');
   });
 });

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -380,6 +380,53 @@ describe('PII redaction', () => {
     expect(redacted.metadata).toBeUndefined();
   });
 
+  it('should redact camelCase and PascalCase sensitive keys by normalized key name', () => {
+    const config = resolveRedactionConfig({ enabled: true });
+    const referenceContext = createRedactionReferenceContext();
+
+    const redacted = redactAttributes(
+      {
+        accessToken: 'Bearer access-secret',
+        refreshToken: 'refresh-secret',
+        clientSecret: 'client-secret',
+        confirmEmail: 'alice@example.com',
+        userEmail: 'alice@example.com',
+        userPhone: '+1 (415) 555-1212',
+        SessionName: 'alice@example.com',
+      },
+      config,
+      referenceContext
+    );
+
+    expect(redacted.value?.accessToken).toBe('[REDACTED_SECRET_A]');
+    expect(redacted.value?.refreshToken).toBe('[REDACTED_SECRET_B]');
+    expect(redacted.value?.clientSecret).toBe('[REDACTED_SECRET_C]');
+    expect(redacted.value?.confirmEmail).toBe('[REDACTED_EMAIL_A]');
+    expect(redacted.value?.userEmail).toBe('[REDACTED_EMAIL_A]');
+    expect(redacted.value?.userPhone).toBe('[REDACTED_PHONE_A]');
+    expect(redacted.value?.SessionName).toBe('[REDACTED_EMAIL_A]');
+  });
+
+  it('should normalize fully-populated config objects before reuse checks', () => {
+    const resolved = resolveRedactionConfig({
+      enabled: true,
+      redactInputs: true,
+      redactOutputs: true,
+      redactAttributes: true,
+      redactErrors: true,
+      redactSessionNames: true,
+      redactTagValues: true,
+      sensitiveKeys: ['accessToken', 'ClientSecret'],
+      customPatterns: ['secret-value'],
+    });
+
+    expect(resolved.sensitiveKeys).toEqual(
+      expect.arrayContaining(['access_token', 'client_secret', 'email'])
+    );
+    expect(resolved.customPatterns[0]).toBeInstanceOf(RegExp);
+    expect(resolved.customPatterns[0].source).toContain('secret-value');
+  });
+
   it('should reuse identical authorization and cookie header values and separate different ones', () => {
     const span = new Span('header-redaction', undefined, {
       enabled: true,

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -96,6 +96,25 @@ describe('PII redaction', () => {
     expect(json.output_data).toContain('[REDACTED_SECRET]');
   });
 
+  it('should handle circular payloads without throwing and keep output serializable', () => {
+    const span = new Span('circular-redaction', undefined, {
+      enabled: true,
+    });
+    const payload: Record<string, unknown> = {
+      email: 'alice@example.com',
+    };
+    payload.self = payload;
+
+    expect(() => span.setIO(payload, payload)).not.toThrow();
+
+    const json = span.toJSON();
+
+    expect(json.input_data).toContain('[REDACTED_EMAIL]');
+    expect(json.input_data).toContain('[Circular]');
+    expect(json.output_data).toContain('[REDACTED_EMAIL]');
+    expect(json.output_data).toContain('[Circular]');
+  });
+
   it('should honor ZEROEVAL_REDACT_PII in init()', async () => {
     const mockWriter = new MockSpanWriter();
     (tracer as any)._writer = mockWriter;

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { init } from '../../src/init';
+import { Span } from '../../src/observability/Span';
+import { tracer } from '../../src/observability/Tracer';
+import { Logger } from '../../src/observability/logger';
+import { BackendSpanWriter } from '../../src/observability/writer';
+import { MockSpanWriter } from '../setup';
+
+describe('PII redaction', () => {
+  let originalFetch: typeof global.fetch | undefined;
+  let originalEnvValue: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    originalEnvValue = process.env.ZEROEVAL_REDACT_PII;
+    delete process.env.ZEROEVAL_REDACT_PII;
+  });
+
+  afterEach(async () => {
+    process.env.ZEROEVAL_REDACT_PII = originalEnvValue;
+    tracer.configure({
+      redaction: { enabled: false },
+    });
+    Logger.setDebugMode(false);
+    vi.restoreAllMocks();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as { fetch?: typeof global.fetch }).fetch;
+    }
+    await tracer.flush();
+  });
+
+  it('should redact manual setIO payloads and error messages', () => {
+    const span = new Span('manual-redaction', undefined, {
+      enabled: true,
+    });
+
+    span.setIO(
+      {
+        email: 'alice@example.com',
+        phone: '+1 (415) 555-1212',
+        payment: '4111 1111 1111 1111',
+        auth: 'Bearer token-123',
+      },
+      'Reply to alice@example.com from 2001:db8::1'
+    );
+    span.setError({
+      code: 'TEST_ERROR',
+      message:
+        'Cookie: sessionid=abc123; user_email=alice@example.com; ssn=123-45-6789',
+    });
+
+    const json = span.toJSON();
+
+    expect(json.input_data).toContain('[REDACTED_EMAIL]');
+    expect(json.input_data).toContain('[REDACTED_PHONE]');
+    expect(json.input_data).toContain('[REDACTED_PAN]');
+    expect(json.input_data).toContain('[REDACTED_SECRET]');
+    expect(json.output_data).toContain('[REDACTED_EMAIL]');
+    expect(json.output_data).toContain('[REDACTED_IP]');
+    expect(json.error_message).toContain('[REDACTED_SECRET]');
+    expect(json.error_message).not.toContain('alice@example.com');
+    expect(json.error_message).not.toContain('123-45-6789');
+    expect(json.attributes).toHaveProperty('zeroeval_redaction');
+  });
+
+  it('should preserve existing behavior when redaction is disabled', () => {
+    const span = new Span('disabled-redaction');
+    span.setIO(
+      { email: 'alice@example.com', token: 'Bearer token-123' },
+      'Call +1 (415) 555-1212'
+    );
+
+    const json = span.toJSON();
+
+    expect(json.input_data).toContain('alice@example.com');
+    expect(json.input_data).toContain('Bearer token-123');
+    expect(json.output_data).toContain('+1 (415) 555-1212');
+    expect(json.attributes).not.toHaveProperty('zeroeval_redaction');
+  });
+
+  it('should redact free-text string payloads', () => {
+    const span = new Span('string-redaction', undefined, {
+      enabled: true,
+    });
+
+    span.setIO(
+      'Call me at +1 (415) 555-1212',
+      'JWT eyJhbGciOiJIUzI1NiJ9.foo.bar'
+    );
+
+    const json = span.toJSON();
+
+    expect(json.input_data).toContain('[REDACTED_PHONE]');
+    expect(json.output_data).toContain('[REDACTED_SECRET]');
+  });
+
+  it('should honor ZEROEVAL_REDACT_PII in init()', async () => {
+    const mockWriter = new MockSpanWriter();
+    (tracer as any)._writer = mockWriter;
+    (tracer as any)._shuttingDown = false;
+    process.env.ZEROEVAL_REDACT_PII = 'true';
+
+    init({ apiKey: 'test-key' });
+
+    const span = tracer.startSpan('env-redaction');
+    span.setIO('Contact alice@example.com', 'Token sk-secret-123456789');
+    tracer.endSpan(span);
+    await tracer.flush();
+
+    expect(mockWriter.spans).toHaveLength(1);
+    expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL]');
+    expect(mockWriter.spans[0].output_data).toContain('[REDACTED_SECRET]');
+  });
+
+  it('should redact writer debug logs before logging or sending spans', async () => {
+    const writer = new BackendSpanWriter();
+    writer.setRedactionConfig({ enabled: true });
+
+    const requestBodies: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url, init) => {
+      requestBodies.push(String(init?.body ?? ''));
+      return {
+        ok: true,
+        status: 200,
+        text: async () => 'ok',
+        headers: { forEach: () => undefined },
+      } as Response;
+    });
+
+    Logger.setDebugMode(true);
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await writer.write([
+      {
+        span_id: 'span-1',
+        trace_id: 'trace-1',
+        name: 'writer-redaction',
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        duration_ms: 1,
+        status: 'ok',
+        session_id: 'alice@example.com',
+        session_name: 'Alice alice@example.com',
+        attributes: {
+          authorization: 'Bearer live-token',
+        },
+        input_data: 'Reach alice@example.com',
+        output_data: '4111 1111 1111 1111',
+        error_message: 'Cookie: secret=abc',
+        error_stack: 'Cookie: secret=abc',
+        tags: {
+          customer_email: 'alice@example.com',
+        },
+        trace_tags: {},
+        session_tags: {},
+      },
+    ]);
+
+    expect(requestBodies).toHaveLength(1);
+    expect(requestBodies[0]).toContain('[REDACTED_EMAIL]');
+    expect(requestBodies[0]).toContain('[REDACTED_PAN]');
+    expect(requestBodies[0]).not.toContain('alice@example.com');
+    expect(requestBodies[0]).not.toContain('4111 1111 1111 1111');
+
+    const combinedLogs = consoleLogSpy.mock.calls
+      .flat()
+      .map((item) => String(item))
+      .join('\n');
+
+    expect(combinedLogs).toContain('[REDACTED_EMAIL]');
+    expect(combinedLogs).not.toContain('alice@example.com');
+    expect(combinedLogs).not.toContain('live-token');
+  });
+});

--- a/tests/core/redaction.test.ts
+++ b/tests/core/redaction.test.ts
@@ -8,6 +8,7 @@ import {
   createRedactionReferenceContext,
   redactAttributes,
   redactSessionIdentifier,
+  redactTags,
   resolveRedactionConfig,
 } from '../../src/observability/redaction';
 import { MockSpanWriter } from '../setup';
@@ -427,6 +428,52 @@ describe('PII redaction', () => {
 
     expect(redacted.value).toBe(attributes);
     expect(redacted.metadata).toBeUndefined();
+  });
+
+  it('should not count empty or missing sensitive-key values as redacted', () => {
+    const config = resolveRedactionConfig({ enabled: true });
+
+    const attributes = redactAttributes(
+      {
+        password: '',
+        apiKey: null,
+        refreshToken: undefined,
+        confirmEmail: 'alice@example.com',
+      },
+      config,
+      createRedactionReferenceContext()
+    );
+
+    expect(attributes.value).toMatchObject({
+      password: '',
+      apiKey: null,
+      refreshToken: undefined,
+      confirmEmail: '[REDACTED_EMAIL_A]',
+    });
+    expect(attributes.metadata).toEqual({
+      enabled: true,
+      count: 1,
+      types: ['EMAIL'],
+    });
+
+    const tags = redactTags(
+      {
+        authToken: '',
+        backupEmail: 'alice@example.com',
+      },
+      config,
+      createRedactionReferenceContext()
+    );
+
+    expect(tags.value).toEqual({
+      authToken: '',
+      backupEmail: '[REDACTED_EMAIL_A]',
+    });
+    expect(tags.metadata).toEqual({
+      enabled: true,
+      count: 1,
+      types: ['EMAIL'],
+    });
   });
 
   it('should redact camelCase and PascalCase sensitive keys by normalized key name', () => {

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -386,6 +386,35 @@ describe('Tracer', () => {
       );
     });
 
+    it('should not fan session tags out across unrelated traces for ambiguous public session identifiers', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const span1 = tracer.startSpan('trace-1', {
+        sessionId: 'alice@example.com',
+      });
+      const publicSessionId = span1.sessionId;
+      tracer.endSpan(span1);
+
+      const span2 = tracer.startSpan('trace-2', {
+        sessionId: 'bob@example.com',
+      });
+      expect(span2.sessionId).toBe(publicSessionId);
+      tracer.endSpan(span2);
+
+      tracer.addSessionTags(publicSessionId, {
+        customer_email: 'alice@example.com',
+      });
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+      for (const span of mockWriter.spans) {
+        expect(span.tags.customer_email).toBeUndefined();
+        expect(span.session_tags.customer_email).toBeUndefined();
+      }
+    });
+
     it('should not log raw session identifiers when adding session tags with redaction enabled', () => {
       tracer.configure({
         redaction: { enabled: true },

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestTracer, sleep } from '../setup';
+import { Logger } from '../../src/observability/logger';
 
 describe('Tracer', () => {
   let tracer: any;
@@ -7,6 +8,11 @@ describe('Tracer', () => {
 
   beforeEach(() => {
     ({ tracer, mockWriter } = createTestTracer());
+  });
+
+  afterEach(() => {
+    Logger.setDebugMode(false);
+    vi.restoreAllMocks();
   });
 
   describe('span creation', () => {
@@ -336,6 +342,30 @@ describe('Tracer', () => {
       expect(mockWriter.spans[1].tags.customer_email).toBe(
         '[REDACTED_EMAIL_A]'
       );
+    });
+
+    it('should not log raw session identifiers when adding session tags with redaction enabled', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+      Logger.setDebugMode(true);
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+      const sessionId = 'alice@example.com';
+
+      const span = tracer.startSpan('span1', { sessionId });
+      tracer.endSpan(span);
+
+      tracer.addSessionTags(sessionId, { customer_email: sessionId });
+
+      const combinedLogs = consoleLogSpy.mock.calls
+        .flat()
+        .map((item) => String(item))
+        .join('\n');
+
+      expect(combinedLogs).toContain('[REDACTED_EMAIL_A]');
+      expect(combinedLogs).not.toContain('alice@example.com');
     });
 
     it('should reuse placeholders across parent and child spans in one trace', () => {

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -344,6 +344,36 @@ describe('Tracer', () => {
       );
     });
 
+    it('should propagate session tags when called with the redacted public session identifier', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const rawSessionId = 'alice@example.com';
+
+      const span1 = tracer.startSpan('span1', { sessionId: rawSessionId });
+      const publicSessionId = span1.sessionId;
+      expect(publicSessionId).toContain('[REDACTED_EMAIL_');
+      tracer.endSpan(span1);
+
+      tracer.addSessionTags(publicSessionId, {
+        customer_email: rawSessionId,
+      });
+
+      const span2 = tracer.startSpan('span2', { sessionId: rawSessionId });
+      tracer.endSpan(span2);
+
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+      expect(mockWriter.spans[0].tags.customer_email).toBe(
+        '[REDACTED_EMAIL_A]'
+      );
+      expect(mockWriter.spans[1].tags.customer_email).toBe(
+        '[REDACTED_EMAIL_A]'
+      );
+    });
+
     it('should not log raw session identifiers when adding session tags with redaction enabled', () => {
       tracer.configure({
         redaction: { enabled: true },

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -296,13 +296,15 @@ describe('Tracer', () => {
       expect(mockWriter.spans[0].session_id).toBe(
         mockWriter.spans[1].session_id
       );
-      expect(mockWriter.spans[0].session_name).toContain('[REDACTED_EMAIL]');
-      expect(mockWriter.spans[0].tags.customer_email).toBe('[REDACTED_EMAIL]');
+      expect(mockWriter.spans[0].session_name).toContain('[REDACTED_EMAIL_A]');
+      expect(mockWriter.spans[0].tags.customer_email).toBe(
+        '[REDACTED_EMAIL_A]'
+      );
       expect(mockWriter.spans[0].attributes.authorization).toBe(
-        '[REDACTED_SECRET]'
+        '[REDACTED_SECRET_A]'
       );
       expect(mockWriter.spans[0].attributes.messages[0].content).toContain(
-        '[REDACTED_EMAIL]'
+        '[REDACTED_EMAIL_A]'
       );
     });
 
@@ -328,8 +330,66 @@ describe('Tracer', () => {
       expect(mockWriter.spans[0].session_id).toBe(
         mockWriter.spans[1].session_id
       );
-      expect(mockWriter.spans[0].tags.customer_email).toBe('[REDACTED_EMAIL]');
-      expect(mockWriter.spans[1].tags.customer_email).toBe('[REDACTED_EMAIL]');
+      expect(mockWriter.spans[0].tags.customer_email).toBe(
+        '[REDACTED_EMAIL_A]'
+      );
+      expect(mockWriter.spans[1].tags.customer_email).toBe(
+        '[REDACTED_EMAIL_A]'
+      );
+    });
+
+    it('should reuse placeholders across parent and child spans in one trace', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const parent = tracer.startSpan('parent', {
+        attributes: {
+          email: 'seb@zeroeval.com',
+        },
+      });
+      parent.setIO('parent seb@zeroeval.com', undefined);
+
+      const child = tracer.startSpan('child');
+      child.setIO('child seb@zeroeval.com', 'other alt@example.com');
+      tracer.endSpan(child);
+
+      parent.setError({ message: 'error seb@zeroeval.com' });
+      tracer.endSpan(parent);
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+
+      const serializedParent = JSON.stringify(
+        mockWriter.spans.find((span: any) => span.name === 'parent')
+      );
+      const serializedChild = JSON.stringify(
+        mockWriter.spans.find((span: any) => span.name === 'child')
+      );
+
+      expect(serializedParent).toContain('[REDACTED_EMAIL_A]');
+      expect(serializedChild).toContain('[REDACTED_EMAIL_A]');
+      expect(serializedChild).toContain('[REDACTED_EMAIL_B]');
+    });
+
+    it('should restart placeholder assignment for different traces', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const trace1 = tracer.startSpan('trace1');
+      trace1.setIO('seb@zeroeval.com', undefined);
+      tracer.endSpan(trace1);
+
+      const trace2 = tracer.startSpan('trace2');
+      trace2.setIO('seb@zeroeval.com', undefined);
+      tracer.endSpan(trace2);
+
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+      expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL_A]');
+      expect(mockWriter.spans[1].input_data).toContain('[REDACTED_EMAIL_A]');
     });
   });
 

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -305,6 +305,32 @@ describe('Tracer', () => {
         '[REDACTED_EMAIL]'
       );
     });
+
+    it('should propagate session tags using the original session identifier when redacted', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const sessionId = 'alice@example.com';
+
+      const span1 = tracer.startSpan('span1', { sessionId });
+      tracer.endSpan(span1);
+
+      const span2 = tracer.startSpan('span2', { sessionId });
+      tracer.endSpan(span2);
+
+      tracer.addSessionTags(sessionId, { customer_email: sessionId });
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+      expect(mockWriter.spans[0].session_id).toContain('[REDACTED_EMAIL_');
+      expect(mockWriter.spans[1].session_id).toContain('[REDACTED_EMAIL_');
+      expect(mockWriter.spans[0].session_id).toBe(
+        mockWriter.spans[1].session_id
+      );
+      expect(mockWriter.spans[0].tags.customer_email).toBe('[REDACTED_EMAIL]');
+      expect(mockWriter.spans[1].tags.customer_email).toBe('[REDACTED_EMAIL]');
+    });
   });
 
   describe('error handling', () => {

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -162,7 +162,7 @@ describe('Tracer', () => {
       ];
 
       await Promise.all(promises);
-      tracer.flush();
+      await tracer.flush();
 
       expect(mockWriter.spans).toHaveLength(6); // 3 traces * 2 spans each
 
@@ -585,6 +585,33 @@ describe('Tracer', () => {
       expect(tracer._sessionTagMetadata).toEqual({});
     });
 
+    it('should ignore trace tags added after a trace has already been flushed', async () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const span = tracer.startSpan('flushed-trace', {
+        attributes: {
+          owner_email: 'seb@zeroeval.com',
+        },
+      });
+      tracer.endSpan(span);
+
+      await tracer.flush();
+
+      tracer.addTraceTags(span.traceId, {
+        support_email: 'seb@zeroeval.com',
+      });
+
+      expect(tracer._traceTags).toEqual({});
+      expect(tracer._traceTagMetadata).toEqual({});
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].tags.support_email).toBeUndefined();
+      expect(mockWriter.spans[0].attributes.owner_email).toBe(
+        '[REDACTED_EMAIL_A]'
+      );
+    });
+
     it('should decrement session counts using the root session lookup key for the trace', () => {
       const root = tracer.startSpan('root', { sessionId: 'session-root' });
       const child = tracer.startSpan('child');
@@ -663,8 +690,7 @@ describe('Tracer', () => {
       const span = tracer.startSpan('test');
       tracer.endSpan(span);
 
-      // Should not throw
-      expect(() => tracer.flush()).not.toThrow();
+      await expect(tracer.flush()).rejects.toThrow('Write failed');
     });
   });
 
@@ -687,7 +713,7 @@ describe('Tracer', () => {
   });
 
   describe('trace ordering', () => {
-    it('should order spans with parents before children', () => {
+    it('should order spans with parents before children', async () => {
       // Create spans in reverse order
       const child2 = tracer.startSpan('child2');
       const child1 = tracer.startSpan('child1');
@@ -702,7 +728,7 @@ describe('Tracer', () => {
       const root = tracer.startSpan('root');
       tracer.endSpan(root);
 
-      tracer.flush();
+      await tracer.flush();
 
       // Root should come first in the buffer
       const rootIndex = mockWriter.spans.findIndex(

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -726,7 +726,7 @@ describe('Tracer', () => {
   });
 
   describe('isActiveTrace', () => {
-    it('should correctly identify active traces', () => {
+    it('should correctly identify active traces', async () => {
       const span1 = tracer.startSpan('span1');
       const traceId = span1.traceId;
 
@@ -738,7 +738,7 @@ describe('Tracer', () => {
       // Trace should still be active until flushed
       expect(tracer.isActiveTrace(traceId)).toBe(true);
 
-      tracer.flush();
+      await tracer.flush();
 
       // After flush, trace should not be active
       expect(tracer.isActiveTrace(traceId)).toBe(false);

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -585,6 +585,21 @@ describe('Tracer', () => {
       expect(tracer._sessionTagMetadata).toEqual({});
     });
 
+    it('should decrement session counts using the root session lookup key for the trace', () => {
+      const root = tracer.startSpan('root', { sessionId: 'session-root' });
+      const child = tracer.startSpan('child');
+
+      child.sessionLookupId = 'tampered-child-session';
+
+      tracer.endSpan(child);
+      tracer.endSpan(root);
+
+      expect(tracer._activeSessionCounts).toEqual({});
+      expect(tracer._sessionTags).toEqual({});
+      expect(tracer._sessionTagMetadata).toEqual({});
+      expect(tracer._traceSessionLookupIds).toEqual({});
+    });
+
     it('should not retain session tag buckets when no active or buffered spans match', () => {
       tracer.configure({
         redaction: { enabled: true },

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -391,6 +391,36 @@ describe('Tracer', () => {
       expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL_A]');
       expect(mockWriter.spans[1].input_data).toContain('[REDACTED_EMAIL_A]');
     });
+
+    it('should preserve trace redaction context for trace tags added after trace completion but before flush', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const span = tracer.startSpan('completed-trace', {
+        attributes: {
+          owner_email: 'seb@zeroeval.com',
+        },
+      });
+      span.setIO('contact seb@zeroeval.com', undefined);
+      tracer.endSpan(span);
+
+      tracer.addTraceTags(span.traceId, {
+        support_email: 'seb@zeroeval.com',
+        escalation_email: 'other@zeroeval.com',
+      });
+
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].attributes.owner_email).toBe(
+        '[REDACTED_EMAIL_A]'
+      );
+      expect(mockWriter.spans[0].tags.support_email).toBe('[REDACTED_EMAIL_A]');
+      expect(mockWriter.spans[0].tags.escalation_email).toBe(
+        '[REDACTED_EMAIL_B]'
+      );
+    });
   });
 
   describe('error handling', () => {

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -260,6 +260,51 @@ describe('Tracer', () => {
       expect(mockWriter.spans[0].tags).toEqual({ user: 'test-user' });
       expect(mockWriter.spans[1].tags).toEqual({ user: 'test-user' });
     });
+
+    it('should redact session names, sensitive tag values, and attributes', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const span1 = tracer.startSpan('root-span', {
+        sessionId: 'alice@example.com',
+        sessionName: 'Alice alice@example.com',
+        tags: {
+          customer_email: 'alice@example.com',
+        },
+        attributes: {
+          authorization: 'Bearer top-secret-token',
+          messages: [
+            {
+              role: 'user',
+              content: 'Email me at alice@example.com',
+            },
+          ],
+        },
+      });
+      tracer.endSpan(span1);
+
+      const span2 = tracer.startSpan('second-root', {
+        sessionId: 'alice@example.com',
+      });
+      tracer.endSpan(span2);
+
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+      expect(mockWriter.spans[0].session_id).toContain('[REDACTED_EMAIL_');
+      expect(mockWriter.spans[0].session_id).toBe(
+        mockWriter.spans[1].session_id
+      );
+      expect(mockWriter.spans[0].session_name).toContain('[REDACTED_EMAIL]');
+      expect(mockWriter.spans[0].tags.customer_email).toBe('[REDACTED_EMAIL]');
+      expect(mockWriter.spans[0].attributes.authorization).toBe(
+        '[REDACTED_SECRET]'
+      );
+      expect(mockWriter.spans[0].attributes.messages[0].content).toContain(
+        '[REDACTED_EMAIL]'
+      );
+    });
   });
 
   describe('error handling', () => {

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -616,7 +616,7 @@ describe('Tracer', () => {
       const root = tracer.startSpan('root', { sessionId: 'session-root' });
       const child = tracer.startSpan('child');
 
-      child.sessionLookupId = 'tampered-child-session';
+      child._sessionLookupId = 'tampered-child-session';
 
       tracer.endSpan(child);
       tracer.endSpan(root);

--- a/tests/core/tracer.test.ts
+++ b/tests/core/tracer.test.ts
@@ -127,6 +127,18 @@ describe('Tracer', () => {
       // Should not have any spans
       expect(mockWriter.spans).toHaveLength(0);
     });
+
+    it('should not corrupt tracer bookkeeping when spans are ended after shutdown', () => {
+      tracer.shutdown();
+
+      const span = tracer.startSpan('after-shutdown');
+      span.setIO('alice@example.com', 'ok');
+      tracer.endSpan(span);
+
+      expect(tracer._activeTraceCounts).toEqual({});
+      expect(tracer._traceBuckets).toEqual({});
+      expect(tracer._buffer).toEqual([]);
+    });
   });
 
   describe('async context management', () => {
@@ -480,6 +492,100 @@ describe('Tracer', () => {
       expect(mockWriter.spans[0].tags.escalation_email).toBe(
         '[REDACTED_EMAIL_B]'
       );
+    });
+
+    it('should preserve redaction metadata for tags added after span creation', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const sessionId = 'alice@example.com';
+      const root = tracer.startSpan('root', { sessionId });
+      const child = tracer.startSpan('child');
+
+      tracer.addTraceTags(root.traceId, {
+        support_email: 'alice@example.com',
+      });
+      tracer.addSessionTags(sessionId, {
+        contact_phone: '+1 (415) 555-1212',
+      });
+
+      tracer.endSpan(child);
+      tracer.endSpan(root);
+      tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+      for (const span of mockWriter.spans) {
+        expect(span.trace_tags.support_email).toBe('[REDACTED_EMAIL_A]');
+        expect(span.session_tags.contact_phone).toBe('[REDACTED_PHONE_A]');
+        expect(span.attributes.zeroeval_redaction).toMatchObject({
+          enabled: true,
+        });
+        expect(span.attributes.zeroeval_redaction.types).toEqual(
+          expect.arrayContaining(['EMAIL', 'PHONE'])
+        );
+      }
+    });
+
+    it('should clean up trace and session tag bookkeeping after flush', async () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const sessionId = 'alice@example.com';
+      const span = tracer.startSpan('cleanup-span', { sessionId });
+      tracer.endSpan(span);
+
+      tracer.addTraceTags(span.traceId, {
+        support_email: 'alice@example.com',
+      });
+      tracer.addSessionTags(span.sessionId, {
+        contact_phone: '+1 (415) 555-1212',
+      });
+
+      expect(Object.keys(tracer._traceTags)).toHaveLength(1);
+      expect(Object.keys(tracer._traceTagMetadata)).toHaveLength(1);
+      expect(Object.keys(tracer._sessionTags)).toHaveLength(1);
+      expect(Object.keys(tracer._sessionTagMetadata)).toHaveLength(1);
+
+      await tracer.flush();
+
+      expect(tracer._traceTags).toEqual({});
+      expect(tracer._traceTagMetadata).toEqual({});
+      expect(tracer._sessionTags).toEqual({});
+      expect(tracer._sessionTagMetadata).toEqual({});
+    });
+
+    it('should not retain session tag buckets when no active or buffered spans match', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      tracer.addSessionTags('orphan@example.com', {
+        customer_email: 'orphan@example.com',
+      });
+
+      expect(tracer._sessionTags).toEqual({});
+      expect(tracer._sessionTagMetadata).toEqual({});
+    });
+
+    it('should attach metadata when sanitizeTags is used with attributes', () => {
+      tracer.configure({
+        redaction: { enabled: true },
+      });
+
+      const attributes: Record<string, unknown> = {};
+      const tags = tracer.sanitizeTags(
+        { customer_email: 'alice@example.com' },
+        undefined,
+        attributes
+      );
+
+      expect(tags.customer_email).toBe('[REDACTED_EMAIL]');
+      expect(attributes.zeroeval_redaction).toMatchObject({
+        enabled: true,
+        types: ['EMAIL'],
+      });
     });
   });
 

--- a/tests/core/wrapper-redaction.test.ts
+++ b/tests/core/wrapper-redaction.test.ts
@@ -161,4 +161,33 @@ describe('wrapper redaction', () => {
     expect(serializedAttributes).not.toContain('bob@example.com');
     expect(serializedAttributes).not.toContain('secret-token');
   });
+
+  it('should preserve existing input placeholders when LangChain callback handler ends a span', async () => {
+    const handler = new ZeroEvalCallbackHandler();
+
+    await handler.handleChainStart(
+      {
+        id: ['langchain', 'chains', 'ExampleChain'],
+        name: 'ExampleChain',
+      } as any,
+      {
+        email: 'bob@example.com',
+      },
+      'run-chain-1'
+    );
+
+    await handler.handleChainEnd(
+      {
+        result: 'ok',
+      } as any,
+      'run-chain-1'
+    );
+
+    await tracer.flush();
+    handler.destroy();
+
+    expect(mockWriter.spans).toHaveLength(1);
+    expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL_A]');
+    expect(mockWriter.spans[0].input_data).not.toContain('[REDACTED_SECRET');
+  });
 });

--- a/tests/core/wrapper-redaction.test.ts
+++ b/tests/core/wrapper-redaction.test.ts
@@ -61,11 +61,13 @@ describe('wrapper redaction', () => {
 
     expect(mockWriter.spans).toHaveLength(1);
     const span = mockWriter.spans[0];
-    expect(span.attributes.messages[0].content).toContain('[REDACTED_EMAIL]');
-    expect(span.attributes.messages[0].content).toContain('[REDACTED_SECRET]');
+    expect(span.attributes.messages[0].content).toContain('[REDACTED_EMAIL_A]');
+    expect(span.attributes.messages[0].content).toContain(
+      '[REDACTED_SECRET_A]'
+    );
     expect(span.input_data).not.toContain('bob@example.com');
-    expect(span.output_data).toContain('[REDACTED_EMAIL]');
-    expect(span.output_data).toContain('[REDACTED_PHONE]');
+    expect(span.output_data).toContain('[REDACTED_EMAIL_A]');
+    expect(span.output_data).toContain('[REDACTED_PHONE_A]');
   });
 
   it('should redact Vercel AI wrapper prompts and outputs', async () => {
@@ -87,8 +89,8 @@ describe('wrapper redaction', () => {
 
     expect(mockWriter.spans).toHaveLength(1);
     const span = mockWriter.spans[0];
-    expect(span.input_data).toContain('[REDACTED_PHONE]');
-    expect(span.output_data).toContain('[REDACTED_SECRET]');
+    expect(span.input_data).toContain('[REDACTED_PHONE_A]');
+    expect(span.output_data).toContain('[REDACTED_SECRET_A]');
   });
 
   it('should redact LangChain callback handler inputs, outputs, and tool args', async () => {
@@ -145,10 +147,10 @@ describe('wrapper redaction', () => {
     const span = mockWriter.spans[0];
     const serializedAttributes = JSON.stringify(span.attributes);
 
-    expect(span.input_data).toContain('[REDACTED_EMAIL]');
-    expect(span.output_data).toContain('[REDACTED_PHONE]');
-    expect(serializedAttributes).toContain('[REDACTED_EMAIL]');
-    expect(serializedAttributes).toContain('[REDACTED_SECRET]');
+    expect(span.input_data).toContain('[REDACTED_EMAIL_A]');
+    expect(span.output_data).toContain('[REDACTED_PHONE_A]');
+    expect(serializedAttributes).toContain('[REDACTED_EMAIL_A]');
+    expect(serializedAttributes).toContain('[REDACTED_SECRET_A]');
     expect(serializedAttributes).not.toContain('bob@example.com');
     expect(serializedAttributes).not.toContain('secret-token');
   });

--- a/tests/core/wrapper-redaction.test.ts
+++ b/tests/core/wrapper-redaction.test.ts
@@ -1,0 +1,155 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tracer } from '../../src/observability/Tracer';
+import { ZeroEvalCallbackHandler } from '../../src/observability/integrations/langchain/ZeroEvalCallbackHandler';
+import { wrapOpenAI } from '../../src/observability/integrations/openaiWrapper';
+import { wrapVercelAI } from '../../src/observability/integrations/vercelAIWrapper';
+import { MockSpanWriter } from '../setup';
+
+describe('wrapper redaction', () => {
+  let mockWriter: MockSpanWriter;
+
+  beforeEach(() => {
+    mockWriter = new MockSpanWriter();
+    (tracer as any)._writer = mockWriter;
+    (tracer as any)._shuttingDown = false;
+    tracer.configure({
+      redaction: { enabled: true },
+    });
+  });
+
+  afterEach(async () => {
+    await tracer.flush();
+    tracer.configure({
+      redaction: { enabled: false },
+    });
+    mockWriter.clear();
+  });
+
+  it('should redact OpenAI wrapper messages and outputs', async () => {
+    const client = wrapOpenAI({
+      chat: {
+        completions: {
+          create: async () => ({
+            choices: [
+              {
+                message: {
+                  content: 'Reach me at bob@example.com or +1 (415) 555-1212',
+                },
+              },
+            ],
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 12,
+            },
+          }),
+        },
+      },
+    } as any);
+
+    await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Email bob@example.com and use Authorization: Bearer live-secret',
+        },
+      ],
+    });
+    await tracer.flush();
+
+    expect(mockWriter.spans).toHaveLength(1);
+    const span = mockWriter.spans[0];
+    expect(span.attributes.messages[0].content).toContain('[REDACTED_EMAIL]');
+    expect(span.attributes.messages[0].content).toContain('[REDACTED_SECRET]');
+    expect(span.input_data).not.toContain('bob@example.com');
+    expect(span.output_data).toContain('[REDACTED_EMAIL]');
+    expect(span.output_data).toContain('[REDACTED_PHONE]');
+  });
+
+  it('should redact Vercel AI wrapper prompts and outputs', async () => {
+    const ai = wrapVercelAI({
+      generateText: async () => ({
+        text: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.foo.bar',
+        usage: {
+          promptTokens: 5,
+          completionTokens: 7,
+        },
+      }),
+    });
+
+    await ai.generateText({
+      model: 'gpt-4.1-mini',
+      prompt: 'Call me at +1 (415) 555-1212',
+    });
+    await tracer.flush();
+
+    expect(mockWriter.spans).toHaveLength(1);
+    const span = mockWriter.spans[0];
+    expect(span.input_data).toContain('[REDACTED_PHONE]');
+    expect(span.output_data).toContain('[REDACTED_SECRET]');
+  });
+
+  it('should redact LangChain callback handler inputs, outputs, and tool args', async () => {
+    const handler = new ZeroEvalCallbackHandler();
+
+    await handler.handleChatModelStart(
+      {
+        id: ['langchain', 'chat_models', 'ChatOpenAI'],
+        name: 'ChatOpenAI',
+      } as any,
+      [[new HumanMessage('Contact bob@example.com')]],
+      'run-1',
+      undefined,
+      {
+        options: {} as any,
+        invocation_params: {
+          model: 'gpt-4o',
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'lookup_user',
+                arguments:
+                  '{"email":"bob@example.com","token":"Bearer secret-token"}',
+              },
+            },
+          ],
+        },
+        batch_size: 1,
+      },
+      undefined,
+      {
+        arguments:
+          '{"email":"bob@example.com","authorization":"Bearer secret-token"}',
+      }
+    );
+
+    await handler.handleLLMEnd(
+      {
+        llmOutput: {
+          tokenUsage: {
+            promptTokens: 10,
+            completionTokens: 4,
+          },
+        },
+        generations: [[{ text: 'Caller +1 (415) 555-1212' }]],
+      } as any,
+      'run-1'
+    );
+    await tracer.flush();
+    handler.destroy();
+
+    expect(mockWriter.spans).toHaveLength(1);
+    const span = mockWriter.spans[0];
+    const serializedAttributes = JSON.stringify(span.attributes);
+
+    expect(span.input_data).toContain('[REDACTED_EMAIL]');
+    expect(span.output_data).toContain('[REDACTED_PHONE]');
+    expect(serializedAttributes).toContain('[REDACTED_EMAIL]');
+    expect(serializedAttributes).toContain('[REDACTED_SECRET]');
+    expect(serializedAttributes).not.toContain('bob@example.com');
+    expect(serializedAttributes).not.toContain('secret-token');
+  });
+});

--- a/tests/core/wrapper-redaction.test.ts
+++ b/tests/core/wrapper-redaction.test.ts
@@ -13,6 +13,13 @@ describe('wrapper redaction', () => {
     mockWriter = new MockSpanWriter();
     (tracer as any)._writer = mockWriter;
     (tracer as any)._shuttingDown = false;
+    (tracer as any)._buffer = [];
+    (tracer as any)._traceBuckets = {};
+    (tracer as any)._activeTraceCounts = {};
+    (tracer as any)._traceTags = {};
+    (tracer as any)._sessionTags = {};
+    (tracer as any)._activeSessionCounts = {};
+    (tracer as any)._traceRedactionContexts = {};
     tracer.configure({
       redaction: { enabled: true },
     });

--- a/tests/core/wrapper-redaction.test.ts
+++ b/tests/core/wrapper-redaction.test.ts
@@ -17,7 +17,9 @@ describe('wrapper redaction', () => {
     (tracer as any)._traceBuckets = {};
     (tracer as any)._activeTraceCounts = {};
     (tracer as any)._traceTags = {};
+    (tracer as any)._traceTagMetadata = {};
     (tracer as any)._sessionTags = {};
+    (tracer as any)._sessionTagMetadata = {};
     (tracer as any)._activeSessionCounts = {};
     (tracer as any)._traceRedactionContexts = {};
     tracer.configure({
@@ -189,5 +191,26 @@ describe('wrapper redaction', () => {
     expect(mockWriter.spans).toHaveLength(1);
     expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL_A]');
     expect(mockWriter.spans[0].input_data).not.toContain('[REDACTED_SECRET');
+  });
+
+  it('should fall back to an empty object for falsy Vercel generateObject results', async () => {
+    const ai = wrapVercelAI({
+      generateObject: async () => ({
+        object: '',
+        usage: {
+          promptTokens: 2,
+          completionTokens: 1,
+        },
+      }),
+    });
+
+    await ai.generateObject({
+      model: 'gpt-4.1-mini',
+      prompt: 'return empty object',
+    });
+    await tracer.flush();
+
+    expect(mockWriter.spans).toHaveLength(1);
+    expect(mockWriter.spans[0].output_data).toBe('{}');
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,9 +1,17 @@
 import { vi } from 'vitest';
 
 // Mock the integration utils to prevent dynamic imports of optional dependencies
-vi.mock('./src/observability/integrations/utils', () => ({
-  discoverIntegrations: vi.fn().mockResolvedValue({}),
-}));
+vi.mock('./src/observability/integrations/utils', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('./src/observability/integrations/utils')
+    >();
+
+  return {
+    ...actual,
+    discoverIntegrations: vi.fn().mockResolvedValue({}),
+  };
+});
 
 // Mock process.on to prevent event listener warnings
 global.process.on = vi.fn() as any;


### PR DESCRIPTION
This PR adds opt-in source-side PII redaction to the TypeScript SDK, scrubbing sensitive data before spans are buffered, logged, or sent to the backend. Redaction is disabled by default and enabled via `init({ redaction: { enabled: true } })` or `ZEROEVAL_REDACT_PII=true`. The implementation follows defense-in-depth by redacting at three layers (Span, Tracer, Writer) and supports structured payloads, free-text strings, and key-based detection with built-in patterns for email/phone/SSN/PAN/secrets/headers/cookies/IPs.

### Core changes

- **`src/observability/redaction.ts`**: Central redaction engine with recursive object/array/string traversal, JSON-string parsing, key-based redaction, built-in detectors (EMAIL, PHONE, SSN, PAN, SECRET, IP), stable hashed session identifier placeholders, and compact `zeroeval_redaction` metadata
- **`src/init.ts`**: Extend `InitOptions` with `redaction?: Partial<RedactionConfig>`; resolve and propagate config to Tracer; honor `ZEROEVAL_REDACT_PII=true` env var
- **`src/observability/Span.ts`**: Constructor accepts redaction config; `setIO()` redacts input/output before storage; `setError()` redacts message/stack; use `safeSerialize` for circular-safe JSON stringify
- **`src/observability/Tracer.ts`**: Store redaction config; redact attributes, tags, session names, and session IDs in `startSpan`; add `_traceTags` and `_sessionTags` for propagation; add `getRedactionConfig()` and `sanitizeTags()` helpers
- **`src/observability/writer.ts`**: Final fail-safe redaction pass before debug logging and `fetch()`; redact all payload fields including session identifiers

### Wrapper and decorator updates

- **`src/observability/spanDecorator.ts`**: Remove premature JSON stringification; pass raw args/results to `
setIO()` so centralized redactor handles structured payloads
- **`src/observability/integrations/openaiWrapper.ts`**: Remove premature JSON stringification in `wrapCompletionsCreate`, `wrapGenericMethod`, and `wrapStream`; pass structured `serializedMessages` and outputs to `setIO()`
- **`src/observability/integrations/vercelAIWrapper.ts`**: Remove premature JSON stringification; pass structured `input` to `setIO()`
- **`src/observability/integrations/langchain.ts`**: Remove premature JSON stringification in invoke/stream wrappers
- **`src/observability/integrations/langgraph.ts`**: Remove premature JSON stringification in invoke/stream wrappers
- **`src/observability/integrations/langchain/ZeroEvalCallbackHandler.ts`**: Remove `LazySerializer`; pass raw `input`/`output` to `setIO()`

### Tests

- **`tests/core/redaction.test.ts`**: New coverage for manual calls, `ZEROEVAL_REDACT_PII` env toggle, writer/debug logging safety, and free-text string payloads
- **`tests/core/wrapper-redaction.test.ts`**: New coverage for OpenAI, Vercel AI SDK, and LangChain wrapper capture paths with redaction enabled
- **`tests/core/decorator.test.ts`**: Added test for decorator-captured inputs/outputs
- **`tests/core/tracer.test.ts`**: Added test for session names, sensitive tag values, and attributes redaction

<a href="https://capy.ai/project/b1c6ede2-717a-4dcf-8e77-9c048dc56142/pull/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b1c6ede2-717a-4dcf-8e77-9c048dc56142/task/73bf9e4f-6d3d-481f-89e5-6fb55bf24810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ZE-5&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ZE-5"><img alt="ZE-5 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ZE-5"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new redaction engine and threads it through `Span`, `Tracer`, and `BackendSpanWriter`, changing how session IDs, tags, attributes, IO, and errors are stored, propagated, and serialized. Although opt-in, it touches core buffering/flushing/tagging paths and could affect trace/session correlation and payload formats if misconfigured.
> 
> **Overview**
> Implements **opt-in, source-side PII redaction** for span data, enabled via `init({ redaction: { enabled: true } })` or `ZEROEVAL_REDACT_PII=true`, and exports `RedactionConfig`.
> 
> Adds a centralized redaction engine (`observability/redaction.ts`) and applies it across the pipeline: `Span` now redacts `setIO()`/`setError()` and supports `setAttributes()`, `Tracer.startSpan()` redacts session identifiers/names, attributes, and tags while preserving placeholder consistency across a trace, and `BackendSpanWriter` performs a final fail-safe redaction pass (including debug logs) before sending spans and flushing signals.
> 
> Updates wrappers/decorator (OpenAI, Vercel AI, LangChain/LangGraph, `@span`) to pass structured inputs/outputs to `setIO()` instead of pre-stringifying, adds an example script for manual verification, bumps package version, and expands tests to cover redaction behavior, placeholder stability, session/trace tag propagation, and edge cases (JSON strings, circular data, shutdown/flush behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca43cf5932cd8b2ad3e52a547fead367e8c3ac0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->