### PR TITLE
Claude Agents SDK Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For full documentation visit https://docs.zeroeval.com.
 
 • **Span decorator & tracer API** – instrument any function with a single line and capture sessions, traces and spans easily.
 
-• **Integrations** – OpenAI client, Vercel AI SDK, and LangChain/LangGraph are traced automatically (optional peer deps).
+• **Integrations** – OpenAI client, Vercel AI SDK, Claude Agent SDK, and LangChain/LangGraph are traced automatically (optional peer deps).
 
 • **Works everywhere** – Node 18+, Bun, browser (Vite / Next.js).
 
@@ -32,6 +32,7 @@ Optional dependencies for integrations:
 npm install openai
 npm install ai @ai-sdk/openai
 npm install langchain
+npm install @anthropic-ai/claude-agent-sdk
 ```
 
 ## Authentication
@@ -102,6 +103,34 @@ const result = await wrappedAI.generateText({
   model: openai("gpt-4o-mini"),
   prompt: "Hello, world!",
 });
+```
+
+### Claude Agent SDK
+
+```ts
+import * as ze from "zeroeval";
+import * as claudeAgentSdk from "@anthropic-ai/claude-agent-sdk";
+
+ze.init();
+
+const sdk = ze.wrapClaudeAgentSdk(claudeAgentSdk);
+// or: const sdk = ze.wrap(claudeAgentSdk);
+
+for await (const message of sdk.query({
+  prompt: "What files are in this directory?",
+  options: { allowedTools: ["Bash", "Glob"] },
+})) {
+  if ("result" in message) console.log(message.result);
+}
+```
+
+You can also wrap just the `query` function directly:
+
+```ts
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import * as ze from "zeroeval";
+
+const tracedQuery = ze.wrapClaudeAgentQuery(query);
 ```
 
 ## License

--- a/examples/11-claude-agent.ts
+++ b/examples/11-claude-agent.ts
@@ -1,0 +1,85 @@
+/**
+ * Example: Tracing Claude Agent SDK with ZeroEval
+ *
+ * Prerequisites:
+ *   npm install @anthropic-ai/claude-agent-sdk
+ *   export ANTHROPIC_API_KEY=your-key
+ *   export ZEROEVAL_API_KEY=your-key
+ *
+ * Run:
+ *   npm run example:claude-agent
+ */
+
+import * as ze from '../src/index';
+
+ze.init();
+
+// ---------------------------------------------------------------------------
+// Option A: Wrap the whole SDK module (recommended)
+// ---------------------------------------------------------------------------
+
+async function oneShot() {
+  // Dynamically import so the example compiles even without the package
+  const claudeAgentSdk = await import('@anthropic-ai/claude-agent-sdk');
+  const sdk = ze.wrapClaudeAgentSdk(claudeAgentSdk);
+
+  console.log('--- One-shot query ---');
+  for await (const message of sdk.query({
+    prompt: 'What files are in this directory?',
+    options: { allowedTools: ['Bash', 'Glob'] },
+  })) {
+    if ('result' in message && message.type === 'result') {
+      console.log('Result:', (message as any).result);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Option B: Wrap only the query function
+// ---------------------------------------------------------------------------
+
+async function wrappedQueryOnly() {
+  const { query } = await import('@anthropic-ai/claude-agent-sdk');
+  const tracedQuery = ze.wrapClaudeAgentQuery(query);
+
+  console.log('--- Wrapped query function ---');
+  for await (const message of tracedQuery({
+    prompt: 'List all TypeScript files',
+    options: { allowedTools: ['Glob'] },
+  })) {
+    if ('result' in message && message.type === 'result') {
+      console.log('Result:', (message as any).result);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Option C: Use ze.wrap() for auto-detection
+// ---------------------------------------------------------------------------
+
+async function autoDetect() {
+  const claudeAgentSdk = await import('@anthropic-ai/claude-agent-sdk');
+  const sdk = ze.wrap(claudeAgentSdk);
+
+  console.log('--- Auto-detected via ze.wrap() ---');
+  for await (const message of (sdk as any).query({
+    prompt: 'Hello!',
+    options: { allowedTools: [] },
+  })) {
+    if ('result' in message && message.type === 'result') {
+      console.log('Result:', (message as any).result);
+    }
+  }
+}
+
+async function main() {
+  try {
+    await oneShot();
+    await wrappedQueryOnly();
+    await autoDetect();
+  } catch (err) {
+    console.error('Example failed:', err);
+  }
+}
+
+main();

--- a/examples/11-claude-agent.ts
+++ b/examples/11-claude-agent.ts
@@ -10,7 +10,7 @@
  *   npm run example:claude-agent
  */
 
-import * as ze from '../src/index';
+import * as ze from 'zeroeval';
 
 ze.init();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeroeval",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeroeval",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "@ai-sdk/anthropic": "^2.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@ai-sdk/anthropic": "^2.0.11",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.104",
         "@eslint/js": "^9.30.1",
         "@langchain/core": "^0.3.75",
         "@types/node": "^20.19.6",
@@ -36,6 +37,7 @@
       },
       "peerDependencies": {
         "@ai-sdk/openai": "^2.0.0",
+        "@anthropic-ai/claude-agent-sdk": ">=0.2.0",
         "@langchain/core": "^0.3.62",
         "@langchain/langgraph": "^0.3.6",
         "ai": "5.0.0-beta.28",
@@ -44,6 +46,9 @@
       },
       "peerDependenciesMeta": {
         "@ai-sdk/openai": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
           "optional": true
         },
         "@langchain/core": {
@@ -160,6 +165,55 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.104",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.104.tgz",
+      "integrity": "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw==",
+      "dev": true,
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -194,6 +248,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -895,6 +959,19 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -959,6 +1036,326 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1051,6 +1448,81 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@langchain/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1945,6 +2417,47 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2016,6 +2529,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
@@ -2158,6 +2713,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2220,6 +2800,16 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.17"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -2421,6 +3011,68 @@
         "simple-wcswidth": "^1.0.1"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2444,9 +3096,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2498,6 +3150,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2543,12 +3205,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2643,6 +3322,13 @@
         "@esbuild/win32-ia32": "0.18.20",
         "@esbuild/win32-x64": "0.18.20"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2932,6 +3618,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -2957,6 +3653,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/eventsource-parser": {
@@ -3010,6 +3719,96 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3055,6 +3854,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3096,6 +3912,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3188,6 +4026,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -3407,12 +4265,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3422,6 +4311,23 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -3492,6 +4398,33 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3547,6 +4480,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3638,6 +4578,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3699,12 +4649,33 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3902,6 +4873,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4057,6 +5051,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -4122,6 +5126,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -4286,6 +5313,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4321,6 +5358,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -4378,6 +5426,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -4494,6 +5552,20 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4541,6 +5613,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -4569,6 +5667,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -4635,6 +5743,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4680,6 +5805,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -4692,6 +5824,87 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4902,6 +6115,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -5262,6 +6485,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -5288,6 +6521,13 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
@@ -5412,6 +6652,48 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -5432,6 +6714,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -5470,6 +6762,16 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "6.3.5",
@@ -6311,6 +7613,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
@@ -6348,9 +7657,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6358,13 +7667,13 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -90,12 +90,12 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai": "^2.0.0",
+    "@anthropic-ai/claude-agent-sdk": ">=0.2.0",
     "@langchain/core": "^0.3.62",
     "@langchain/langgraph": "^0.3.6",
     "ai": "5.0.0-beta.28",
     "langchain": "^0.3.29",
-    "openai": "^5.8.2 || ^6.0.0",
-    "@anthropic-ai/claude-agent-sdk": ">=0.2.0"
+    "openai": "^5.8.2 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/openai": {
@@ -122,12 +122,13 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^2.0.11",
-    "@vapi-ai/server-sdk": "^0.7.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.104",
     "@eslint/js": "^9.30.1",
     "@langchain/core": "^0.3.75",
     "@types/node": "^20.19.6",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
+    "@vapi-ai/server-sdk": "^0.7.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "ai": "^5.0.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroeval",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "ZeroEval TypeScript SDK",
   "keywords": [
     "observability",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "monitoring",
     "langchain",
     "openai",
+    "anthropic",
+    "claude-agent",
     "ai",
     "sdk",
     "analytics"
@@ -83,7 +85,8 @@
     "example:ai-stream-consume": "npm run build && npx ts-node --esm examples/07-ai-stream-consume.ts",
     "example:prompt": "npm run build && npx ts-node --esm examples/08-prompt.ts",
     "example:vapi": "npm run build && npx ts-node --esm examples/09-vapi.ts",
-    "example:pii-redaction": "npm run build && npx ts-node --esm examples/10-pii-redaction.ts"
+    "example:pii-redaction": "npm run build && npx ts-node --esm examples/10-pii-redaction.ts",
+    "example:claude-agent": "npm run build && npx ts-node --esm examples/11-claude-agent.ts"
   },
   "peerDependencies": {
     "@ai-sdk/openai": "^2.0.0",
@@ -91,7 +94,8 @@
     "@langchain/langgraph": "^0.3.6",
     "ai": "5.0.0-beta.28",
     "langchain": "^0.3.29",
-    "openai": "^5.8.2 || ^6.0.0"
+    "openai": "^5.8.2 || ^6.0.0",
+    "@anthropic-ai/claude-agent-sdk": ">=0.2.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/openai": {
@@ -110,6 +114,9 @@
       "optional": true
     },
     "openai": {
+      "optional": true
+    },
+    "@anthropic-ai/claude-agent-sdk": {
       "optional": true
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,11 @@ export { wrap } from './observability/integrations/wrapper';
 export { wrapOpenAI } from './observability/integrations/openaiWrapper';
 // Export wrapVercelAI for direct usage
 export { wrapVercelAI } from './observability/integrations/vercelAIWrapper';
+// Export Claude Agent SDK wrappers
+export {
+  wrapClaudeAgentSdk,
+  wrapClaudeAgentQuery,
+} from './observability/integrations/claudeAgentWrapper';
 export { Span } from './observability/Span';
 export type { RedactionConfig } from './observability/redaction';
 

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -614,20 +614,28 @@ function createWrappedSession(session: SDKSession): SDKSession {
         error = err instanceof Error ? err : new Error(String(err));
         throw err;
       } finally {
-        if (error) {
-          const closed = pending.pop();
-          if (closed) {
+        const closed = pending.pop();
+        if (closed) {
+          try {
+            applyStateToSpan(closed.span, closed.state);
+          } catch {
+            // best-effort
+          }
+          if (error) {
             try {
-              applyStateToSpan(closed.span, closed.state);
               closed.span.setError({
                 code: error.name,
                 message: error.message,
                 stack: error.stack,
               });
-              tracer.endSpan(closed.span);
             } catch {
               // best-effort
             }
+          }
+          try {
+            tracer.endSpan(closed.span);
+          } catch {
+            // best-effort
           }
         }
       }

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -223,18 +223,25 @@ class TurnState {
 // ---------------------------------------------------------------------------
 
 class PendingTurnState {
-  private turns: Array<{ span: ReturnType<typeof tracer.startSpan>; state: TurnState }> = [];
+  private turns: Array<{
+    span: ReturnType<typeof tracer.startSpan>;
+    state: TurnState;
+  }> = [];
 
   push(span: ReturnType<typeof tracer.startSpan>, state: TurnState): void {
     this.turns.push({ span, state });
   }
 
-  peek(): { span: ReturnType<typeof tracer.startSpan>; state: TurnState } | undefined {
-    return this.turns[this.turns.length - 1];
+  peek():
+    | { span: ReturnType<typeof tracer.startSpan>; state: TurnState }
+    | undefined {
+    return this.turns[0];
   }
 
-  pop(): { span: ReturnType<typeof tracer.startSpan>; state: TurnState } | undefined {
-    return this.turns.pop();
+  pop():
+    | { span: ReturnType<typeof tracer.startSpan>; state: TurnState }
+    | undefined {
+    return this.turns.shift();
   }
 
   closeAll(): void {
@@ -323,7 +330,11 @@ function extractMessageData(message: SDKMessage, state: TurnState): void {
         state.resultMeta.terminal_reason = rm.terminal_reason;
       if ('permission_denials' in rm && rm.permission_denials)
         state.resultMeta.permission_denials = rm.permission_denials;
-      if ('result' in rm && typeof rm.result === 'string' && !state.assistantText) {
+      if (
+        'result' in rm &&
+        typeof rm.result === 'string' &&
+        !state.assistantText
+      ) {
         state.assistantText = rm.result;
       }
       break;
@@ -342,7 +353,11 @@ function extractMessageData(message: SDKMessage, state: TurnState): void {
     }
 
     default:
-      if ('session_id' in msg && typeof msg.session_id === 'string' && msg.session_id) {
+      if (
+        'session_id' in msg &&
+        typeof msg.session_id === 'string' &&
+        msg.session_id
+      ) {
         state.claudeSessionId = msg.session_id;
       }
       break;
@@ -390,18 +405,19 @@ function applyStateToSpan(
 // Options wrapping (canUseTool / hooks enrichment)
 // ---------------------------------------------------------------------------
 
-function wrapCanUseTool(
-  original: CanUseTool,
-  state: TurnState
-): CanUseTool {
+function wrapCanUseTool(original: CanUseTool, state: TurnState): CanUseTool {
   return async (toolName, input, options) => {
     const result = await original(toolName, input, options);
     try {
       state.permissionDecisions.push({
         toolName,
         behavior: result?.behavior ?? 'unknown',
-        toolUseID: (options as Record<string, unknown>).toolUseID as string | undefined,
-        agentID: (options as Record<string, unknown>).agentID as string | undefined,
+        toolUseID: (options as Record<string, unknown>).toolUseID as
+          | string
+          | undefined,
+        agentID: (options as Record<string, unknown>).agentID as
+          | string
+          | undefined,
       });
     } catch {
       // best-effort
@@ -643,7 +659,9 @@ function createWrappedSession(session: SDKSession): SDKSession {
 // ---------------------------------------------------------------------------
 
 export function wrapClaudeAgentQuery<T extends QueryFn>(queryFn: T): T {
-  if ((queryFn as unknown as { __zeroeval_wrapped?: boolean }).__zeroeval_wrapped) {
+  if (
+    (queryFn as unknown as { __zeroeval_wrapped?: boolean }).__zeroeval_wrapped
+  ) {
     return queryFn;
   }
 

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -172,17 +172,6 @@ type ResumeSessionFn = (
 ) => SDKSession;
 
 // ---------------------------------------------------------------------------
-// Claude Agent SDK module shape
-// ---------------------------------------------------------------------------
-
-interface ClaudeAgentSdkModule {
-  query: QueryFn;
-  unstable_v2_createSession?: CreateSessionFn;
-  unstable_v2_resumeSession?: ResumeSessionFn;
-  [key: string]: unknown;
-}
-
-// ---------------------------------------------------------------------------
 // Wrapped module type
 // ---------------------------------------------------------------------------
 
@@ -627,7 +616,19 @@ function createWrappedSession(session: SDKSession): SDKSession {
     });
 
     pending.push(span, state);
-    return originalSend(message);
+    try {
+      return await originalSend(message);
+    } catch (err) {
+      pending.pop();
+      const e = err instanceof Error ? err : new Error(String(err));
+      span.setError({
+        code: e.name,
+        message: e.message,
+        stack: e.stack,
+      });
+      tracer.endSpan(span);
+      throw err;
+    }
   };
 
   const wrappedStream = function wrappedSessionStream(): AsyncGenerator<

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -734,7 +734,11 @@ export function wrapClaudeAgentSdk<T extends Record<string, unknown>>(
   }
 
   if (typeof sdkModule.query === 'function') {
-    wrapped.query = createWrappedQuery(sdkModule.query as QueryFn);
+    const wrappedQuery = createWrappedQuery(sdkModule.query as QueryFn);
+    (
+      wrappedQuery as unknown as { __zeroeval_wrapped: boolean }
+    ).__zeroeval_wrapped = true;
+    wrapped.query = wrappedQuery;
   }
 
   if (typeof sdkModule.unstable_v2_createSession === 'function') {

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -478,6 +478,39 @@ function wrapOptions(
 // Query wrapper
 // ---------------------------------------------------------------------------
 
+function preserveQueryMethods(
+  tracedGen: AsyncGenerator<SDKMessage, void>,
+  originalGen: QueryReturn
+): QueryReturn {
+  return new Proxy(tracedGen as QueryReturn, {
+    get(target, prop, receiver) {
+      if (prop in target) {
+        const value = Reflect.get(target, prop, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      }
+      const value = Reflect.get(originalGen as object, prop, originalGen);
+      return typeof value === 'function' ? value.bind(originalGen) : value;
+    },
+    has(target, prop) {
+      return prop in target || prop in originalGen;
+    },
+    ownKeys(target) {
+      return Array.from(
+        new Set([
+          ...Reflect.ownKeys(target as object),
+          ...Reflect.ownKeys(originalGen as object),
+        ])
+      );
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      return (
+        Reflect.getOwnPropertyDescriptor(target as object, prop) ??
+        Reflect.getOwnPropertyDescriptor(originalGen as object, prop)
+      );
+    },
+  });
+}
+
 function createWrappedQuery(originalQuery: QueryFn): QueryFn {
   const wrappedQuery = function wrappedClaudeQuery(
     params: QueryParams
@@ -564,7 +597,7 @@ function createWrappedQuery(originalQuery: QueryFn): QueryFn {
       }
     }
 
-    return tracedGenerator() as QueryReturn;
+    return preserveQueryMethods(tracedGenerator(), originalGen);
   };
 
   return wrappedQuery;

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -1,0 +1,732 @@
+import { tracer } from '../Tracer';
+import { init, isInitialized } from '../../init';
+
+// ---------------------------------------------------------------------------
+// Internal types mirroring the published @anthropic-ai/claude-agent-sdk surface.
+// We avoid importing the real package so the wrapper compiles without it.
+// ---------------------------------------------------------------------------
+
+interface SDKResultSuccess {
+  type: 'result';
+  subtype: 'success';
+  duration_ms: number;
+  duration_api_ms: number;
+  is_error: boolean;
+  num_turns: number;
+  result: string;
+  stop_reason: string | null;
+  total_cost_usd: number;
+  usage: Record<string, unknown>;
+  modelUsage?: Record<string, unknown>;
+  permission_denials?: Array<{ tool_name: string; tool_use_id: string }>;
+  terminal_reason?: string;
+  uuid: string;
+  session_id: string;
+}
+
+interface SDKResultError {
+  type: 'result';
+  subtype: string;
+  is_error: boolean;
+  duration_ms?: number;
+  total_cost_usd?: number;
+  num_turns?: number;
+  uuid: string;
+  session_id: string;
+  [key: string]: unknown;
+}
+
+type SDKResultMessage = SDKResultSuccess | SDKResultError;
+
+interface SDKAssistantMessage {
+  type: 'assistant';
+  message: {
+    content?: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      id?: string;
+      input?: Record<string, unknown>;
+    }>;
+    model?: string;
+    usage?: { input_tokens?: number; output_tokens?: number };
+  };
+  parent_tool_use_id: string | null;
+  uuid: string;
+  session_id: string;
+}
+
+interface SDKPartialAssistantMessage {
+  type: 'stream_event';
+  event: Record<string, unknown>;
+  parent_tool_use_id: string | null;
+  uuid: string;
+  session_id: string;
+}
+
+interface SDKRateLimitEvent {
+  type: 'rate_limit_event';
+  rate_limit_info: {
+    status: string;
+    rateLimitType?: string;
+    utilization?: number;
+  };
+  uuid: string;
+  session_id: string;
+}
+
+interface SDKSystemMessage {
+  type: 'system';
+  subtype: string;
+  session_id?: string;
+  [key: string]: unknown;
+}
+
+interface SDKUserMessage {
+  type: 'user';
+  message: unknown;
+  session_id?: string;
+  [key: string]: unknown;
+}
+
+interface SDKToolUseSummaryMessage {
+  type: 'tool_use_summary';
+  [key: string]: unknown;
+}
+
+interface GenericSDKMessage {
+  type: string;
+  session_id?: string;
+  [key: string]: unknown;
+}
+
+type SDKMessage =
+  | SDKResultMessage
+  | SDKAssistantMessage
+  | SDKPartialAssistantMessage
+  | SDKRateLimitEvent
+  | SDKSystemMessage
+  | SDKUserMessage
+  | SDKToolUseSummaryMessage
+  | GenericSDKMessage;
+
+// ---------------------------------------------------------------------------
+// Callback types mirroring the SDK's CanUseTool / HookCallback
+// ---------------------------------------------------------------------------
+
+type CanUseTool = (
+  toolName: string,
+  input: Record<string, unknown>,
+  options: Record<string, unknown>
+) => Promise<{ behavior?: string; [key: string]: unknown }>;
+
+type HookCallback = (
+  input: Record<string, unknown>,
+  toolUseID: string | undefined,
+  options: Record<string, unknown>
+) => Promise<Record<string, unknown>>;
+
+interface HookCallbackMatcher {
+  matcher?: string;
+  hooks: HookCallback[];
+  timeout?: number;
+}
+
+interface ClaudeAgentOptions {
+  canUseTool?: CanUseTool;
+  hooks?: Record<string, HookCallbackMatcher[]>;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Query function shape
+// ---------------------------------------------------------------------------
+
+type QueryParams = {
+  prompt: string | AsyncIterable<unknown>;
+  options?: ClaudeAgentOptions;
+};
+
+interface QueryReturn extends AsyncGenerator<SDKMessage, void> {
+  [key: string]: unknown;
+}
+
+type QueryFn = (params: QueryParams) => QueryReturn;
+
+// ---------------------------------------------------------------------------
+// Session types (unstable v2)
+// ---------------------------------------------------------------------------
+
+interface SDKSession {
+  readonly sessionId: string;
+  send(message: string | Record<string, unknown>): Promise<void>;
+  stream(): AsyncGenerator<SDKMessage, void>;
+  close(): void;
+  [Symbol.asyncDispose]?(): Promise<void>;
+}
+
+type CreateSessionFn = (options: Record<string, unknown>) => SDKSession;
+type ResumeSessionFn = (
+  sessionId: string,
+  options: Record<string, unknown>
+) => SDKSession;
+
+// ---------------------------------------------------------------------------
+// Claude Agent SDK module shape
+// ---------------------------------------------------------------------------
+
+interface ClaudeAgentSdkModule {
+  query: QueryFn;
+  unstable_v2_createSession?: CreateSessionFn;
+  unstable_v2_resumeSession?: ResumeSessionFn;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Wrapped module type
+// ---------------------------------------------------------------------------
+
+type WrappedClaudeAgentSdk<T> = T & {
+  __zeroeval_wrapped?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// TurnState – accumulates telemetry for a single Claude agent turn
+// ---------------------------------------------------------------------------
+
+class TurnState {
+  promptSummary = '';
+  claudeSessionId: string | null = null;
+  assistantText = '';
+  toolUses: Array<{ name: string; id?: string }> = [];
+  streamEventCount = 0;
+  rateLimitEvents: Array<{
+    status: string;
+    type?: string;
+    utilization?: number;
+  }> = [];
+  permissionDecisions: Array<{
+    toolName: string;
+    behavior: string;
+    toolUseID?: string;
+    agentID?: string;
+  }> = [];
+  hookEvents: Array<{
+    eventName?: string;
+    toolName?: string;
+  }> = [];
+  resultMeta: Record<string, unknown> = {};
+}
+
+// ---------------------------------------------------------------------------
+// Pending turn tracker for session-based multi-turn tracing
+// ---------------------------------------------------------------------------
+
+class PendingTurnState {
+  private turns: Array<{ span: ReturnType<typeof tracer.startSpan>; state: TurnState }> = [];
+
+  push(span: ReturnType<typeof tracer.startSpan>, state: TurnState): void {
+    this.turns.push({ span, state });
+  }
+
+  peek(): { span: ReturnType<typeof tracer.startSpan>; state: TurnState } | undefined {
+    return this.turns[this.turns.length - 1];
+  }
+
+  pop(): { span: ReturnType<typeof tracer.startSpan>; state: TurnState } | undefined {
+    return this.turns.pop();
+  }
+
+  closeAll(): void {
+    for (const { span, state } of this.turns) {
+      try {
+        applyStateToSpan(span, state);
+        span.attributes.interrupted = true;
+        tracer.endSpan(span);
+      } catch {
+        // best-effort
+      }
+    }
+    this.turns = [];
+  }
+
+  get length(): number {
+    return this.turns.length;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message enrichment
+// ---------------------------------------------------------------------------
+
+function summarizePrompt(prompt: unknown): string {
+  if (typeof prompt === 'string') {
+    return prompt.slice(0, 500);
+  }
+  return '<async-iterable>';
+}
+
+function extractMessageData(message: SDKMessage, state: TurnState): void {
+  if (!message || typeof message !== 'object' || !('type' in message)) return;
+
+  const msg = message as SDKMessage;
+
+  switch (msg.type) {
+    case 'assistant': {
+      const am = msg as SDKAssistantMessage;
+      if (am.session_id) state.claudeSessionId = am.session_id;
+      if (am.message?.content) {
+        for (const block of am.message.content) {
+          if (block.type === 'tool_use' && block.name) {
+            state.toolUses.push({ name: block.name, id: block.id });
+          } else if (block.type === 'text' && block.text) {
+            state.assistantText += block.text;
+          }
+        }
+      }
+      break;
+    }
+
+    case 'stream_event': {
+      const se = msg as SDKPartialAssistantMessage;
+      state.streamEventCount++;
+      if (se.session_id) state.claudeSessionId = se.session_id;
+      break;
+    }
+
+    case 'rate_limit_event': {
+      const rle = msg as SDKRateLimitEvent;
+      if (rle.session_id) state.claudeSessionId = rle.session_id;
+      if (rle.rate_limit_info) {
+        state.rateLimitEvents.push({
+          status: rle.rate_limit_info.status,
+          type: rle.rate_limit_info.rateLimitType,
+          utilization: rle.rate_limit_info.utilization,
+        });
+      }
+      break;
+    }
+
+    case 'result': {
+      const rm = msg as SDKResultMessage;
+      if (rm.session_id) state.claudeSessionId = rm.session_id;
+      state.resultMeta = {
+        duration_ms: rm.duration_ms,
+        total_cost_usd: rm.total_cost_usd,
+        num_turns: rm.num_turns,
+        is_error: rm.is_error,
+      };
+      if ('stop_reason' in rm) state.resultMeta.stop_reason = rm.stop_reason;
+      if ('usage' in rm) state.resultMeta.usage = rm.usage;
+      if ('modelUsage' in rm) state.resultMeta.model_usage = rm.modelUsage;
+      if ('terminal_reason' in rm)
+        state.resultMeta.terminal_reason = rm.terminal_reason;
+      if ('permission_denials' in rm && rm.permission_denials)
+        state.resultMeta.permission_denials = rm.permission_denials;
+      if ('result' in rm && typeof rm.result === 'string' && !state.assistantText) {
+        state.assistantText = rm.result;
+      }
+      break;
+    }
+
+    case 'user': {
+      const um = msg as SDKUserMessage;
+      if (um.session_id) state.claudeSessionId = um.session_id;
+      break;
+    }
+
+    case 'system': {
+      const sm = msg as SDKSystemMessage;
+      if (sm.session_id) state.claudeSessionId = sm.session_id;
+      break;
+    }
+
+    default:
+      if ('session_id' in msg && typeof msg.session_id === 'string' && msg.session_id) {
+        state.claudeSessionId = msg.session_id;
+      }
+      break;
+  }
+}
+
+function applyStateToSpan(
+  span: ReturnType<typeof tracer.startSpan>,
+  state: TurnState
+): void {
+  const inputSummary = state.promptSummary || '<unknown>';
+  const outputSummary = state.assistantText
+    ? state.assistantText.slice(0, 2000)
+    : '';
+  span.setIO(inputSummary, outputSummary);
+
+  if (state.claudeSessionId) {
+    span.attributes.claude_session_id = state.claudeSessionId;
+    span.sessionId = state.claudeSessionId;
+  }
+  if (state.toolUses.length > 0) {
+    span.attributes.tool_uses = state.toolUses;
+  }
+  if (state.streamEventCount > 0) {
+    span.attributes.stream_event_count = state.streamEventCount;
+  }
+  if (state.rateLimitEvents.length > 0) {
+    span.attributes.rate_limit_events = state.rateLimitEvents;
+  }
+  if (state.permissionDecisions.length > 0) {
+    span.attributes.permission_decisions = state.permissionDecisions;
+  }
+  if (state.hookEvents.length > 0) {
+    span.attributes.hook_events = state.hookEvents;
+  }
+
+  for (const [key, value] of Object.entries(state.resultMeta)) {
+    if (value !== undefined && value !== null) {
+      span.attributes[key] = value;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Options wrapping (canUseTool / hooks enrichment)
+// ---------------------------------------------------------------------------
+
+function wrapCanUseTool(
+  original: CanUseTool,
+  state: TurnState
+): CanUseTool {
+  return async (toolName, input, options) => {
+    const result = await original(toolName, input, options);
+    try {
+      state.permissionDecisions.push({
+        toolName,
+        behavior: result?.behavior ?? 'unknown',
+        toolUseID: (options as Record<string, unknown>).toolUseID as string | undefined,
+        agentID: (options as Record<string, unknown>).agentID as string | undefined,
+      });
+    } catch {
+      // best-effort
+    }
+    return result;
+  };
+}
+
+function wrapHookCallback(
+  original: HookCallback,
+  state: TurnState
+): HookCallback {
+  return async (input, toolUseID, options) => {
+    const result = await original(input, toolUseID, options);
+    try {
+      state.hookEvents.push({
+        eventName: input?.hook_event_name as string | undefined,
+        toolName: input?.tool_name as string | undefined,
+      });
+    } catch {
+      // best-effort
+    }
+    return result;
+  };
+}
+
+function wrapOptions(
+  options: ClaudeAgentOptions | undefined,
+  state: TurnState
+): ClaudeAgentOptions | undefined {
+  if (!options) return options;
+
+  let needsClone = false;
+  const overrides: Partial<ClaudeAgentOptions> = {};
+
+  if (options.canUseTool) {
+    overrides.canUseTool = wrapCanUseTool(options.canUseTool, state);
+    needsClone = true;
+  }
+
+  if (options.hooks) {
+    const wrappedHooks: Record<string, HookCallbackMatcher[]> = {};
+    for (const [event, matchers] of Object.entries(options.hooks)) {
+      wrappedHooks[event] = matchers.map((matcher) => ({
+        ...matcher,
+        hooks: matcher.hooks.map((cb) => wrapHookCallback(cb, state)),
+      }));
+    }
+    overrides.hooks = wrappedHooks;
+    needsClone = true;
+  }
+
+  if (!needsClone) return options;
+  return { ...options, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Query wrapper
+// ---------------------------------------------------------------------------
+
+function createWrappedQuery(originalQuery: QueryFn): QueryFn {
+  const wrappedQuery = function wrappedClaudeQuery(
+    params: QueryParams
+  ): QueryReturn {
+    const state = new TurnState();
+    state.promptSummary = summarizePrompt(params.prompt);
+
+    const wrappedOptions = wrapOptions(
+      params.options as ClaudeAgentOptions | undefined,
+      state
+    );
+
+    const span = tracer.startSpan('claude_agent.query', {
+      attributes: { integration: 'claude_agent_sdk', kind: 'agent' },
+      tags: { integration: 'claude_agent_sdk' },
+    });
+
+    const originalGen = originalQuery({
+      ...params,
+      options: wrappedOptions as QueryParams['options'],
+    });
+
+    async function* tracedGenerator(): AsyncGenerator<SDKMessage, void> {
+      let error: Error | null = null;
+      try {
+        for await (const message of originalGen) {
+          extractMessageData(message, state);
+          yield message;
+          if (
+            message &&
+            typeof message === 'object' &&
+            'type' in message &&
+            message.type === 'result'
+          ) {
+            break;
+          }
+        }
+      } catch (err) {
+        error = err instanceof Error ? err : new Error(String(err));
+        throw err;
+      } finally {
+        try {
+          applyStateToSpan(span, state);
+        } catch {
+          // best-effort
+        }
+        if (error) {
+          try {
+            span.setError({
+              code: error.name,
+              message: error.message,
+              stack: error.stack,
+            });
+          } catch {
+            // best-effort
+          }
+        }
+        try {
+          tracer.endSpan(span);
+        } catch {
+          // best-effort
+        }
+      }
+    }
+
+    return tracedGenerator() as QueryReturn;
+  };
+
+  return wrappedQuery;
+}
+
+// ---------------------------------------------------------------------------
+// Session wrapper (unstable v2)
+// ---------------------------------------------------------------------------
+
+function createWrappedSession(session: SDKSession): SDKSession {
+  const pending = new PendingTurnState();
+
+  const originalSend = session.send.bind(session);
+  const originalStream = session.stream.bind(session);
+  const originalClose = session.close.bind(session);
+
+  const wrappedSend = async (
+    message: string | Record<string, unknown>
+  ): Promise<void> => {
+    const state = new TurnState();
+    state.promptSummary =
+      typeof message === 'string' ? message.slice(0, 500) : '<structured>';
+
+    const span = tracer.startSpan('claude_agent.turn', {
+      attributes: { integration: 'claude_agent_sdk', kind: 'agent' },
+      tags: { integration: 'claude_agent_sdk' },
+    });
+
+    pending.push(span, state);
+    return originalSend(message);
+  };
+
+  const wrappedStream = function wrappedSessionStream(): AsyncGenerator<
+    SDKMessage,
+    void
+  > {
+    const originalGen = originalStream();
+
+    async function* tracedSessionStream(): AsyncGenerator<SDKMessage, void> {
+      let error: Error | null = null;
+      try {
+        for await (const message of originalGen) {
+          const current = pending.peek();
+          if (current) {
+            extractMessageData(message, current.state);
+          }
+
+          if (
+            message &&
+            typeof message === 'object' &&
+            'type' in message &&
+            message.type === 'result'
+          ) {
+            const closed = pending.pop();
+            if (closed) {
+              try {
+                applyStateToSpan(closed.span, closed.state);
+                tracer.endSpan(closed.span);
+              } catch {
+                // best-effort
+              }
+            }
+          }
+
+          yield message;
+        }
+      } catch (err) {
+        error = err instanceof Error ? err : new Error(String(err));
+        throw err;
+      } finally {
+        if (error) {
+          const closed = pending.pop();
+          if (closed) {
+            try {
+              applyStateToSpan(closed.span, closed.state);
+              closed.span.setError({
+                code: error.name,
+                message: error.message,
+                stack: error.stack,
+              });
+              tracer.endSpan(closed.span);
+            } catch {
+              // best-effort
+            }
+          }
+        }
+      }
+    }
+
+    return tracedSessionStream();
+  };
+
+  const wrappedClose = (): void => {
+    pending.closeAll();
+    originalClose();
+  };
+
+  return {
+    get sessionId() {
+      return session.sessionId;
+    },
+    send: wrappedSend,
+    stream: wrappedStream,
+    close: wrappedClose,
+    async [Symbol.asyncDispose]() {
+      wrappedClose();
+    },
+  } as SDKSession;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: wrapClaudeAgentQuery
+// ---------------------------------------------------------------------------
+
+export function wrapClaudeAgentQuery<T extends QueryFn>(queryFn: T): T {
+  if ((queryFn as unknown as { __zeroeval_wrapped?: boolean }).__zeroeval_wrapped) {
+    return queryFn;
+  }
+
+  if (!isInitialized()) {
+    const envApiKey = process.env.ZEROEVAL_API_KEY;
+    if (envApiKey) {
+      init({ apiKey: envApiKey });
+    }
+  }
+
+  const wrapped = createWrappedQuery(queryFn);
+  (wrapped as unknown as { __zeroeval_wrapped: boolean }).__zeroeval_wrapped =
+    true;
+
+  Object.defineProperty(wrapped, 'name', { value: queryFn.name || 'query' });
+  return wrapped as unknown as T;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: wrapClaudeAgentSdk
+// ---------------------------------------------------------------------------
+
+export function wrapClaudeAgentSdk<T extends Record<string, unknown>>(
+  sdkModule: T
+): WrappedClaudeAgentSdk<T> {
+  if ((sdkModule as WrappedClaudeAgentSdk<T>).__zeroeval_wrapped) {
+    return sdkModule as WrappedClaudeAgentSdk<T>;
+  }
+
+  if (!isInitialized()) {
+    const envApiKey = process.env.ZEROEVAL_API_KEY;
+    if (envApiKey) {
+      init({ apiKey: envApiKey });
+    }
+  }
+
+  const wrapped: Record<string, unknown> = {};
+
+  for (const key of Object.keys(sdkModule)) {
+    wrapped[key] = sdkModule[key];
+  }
+
+  if (typeof sdkModule.query === 'function') {
+    wrapped.query = createWrappedQuery(sdkModule.query as QueryFn);
+  }
+
+  if (typeof sdkModule.unstable_v2_createSession === 'function') {
+    const origCreate = sdkModule.unstable_v2_createSession as CreateSessionFn;
+    wrapped.unstable_v2_createSession = (
+      options: Record<string, unknown>
+    ): SDKSession => {
+      return createWrappedSession(origCreate(options));
+    };
+  }
+
+  if (typeof sdkModule.unstable_v2_resumeSession === 'function') {
+    const origResume = sdkModule.unstable_v2_resumeSession as ResumeSessionFn;
+    wrapped.unstable_v2_resumeSession = (
+      sessionId: string,
+      options: Record<string, unknown>
+    ): SDKSession => {
+      return createWrappedSession(origResume(sessionId, options));
+    };
+  }
+
+  (wrapped as WrappedClaudeAgentSdk<T>).__zeroeval_wrapped = true;
+  Object.setPrototypeOf(wrapped, Object.getPrototypeOf(sdkModule));
+
+  return wrapped as WrappedClaudeAgentSdk<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Module shape detection for ze.wrap()
+// ---------------------------------------------------------------------------
+
+export function isClaudeAgentSdkModule(client: unknown): boolean {
+  if (typeof client !== 'object' || client === null) return false;
+  const obj = client as Record<string, unknown>;
+  return (
+    typeof obj.query === 'function' &&
+    (typeof obj.unstable_v2_createSession === 'function' ||
+      typeof obj.getSessionMessages === 'function' ||
+      typeof obj.listSessions === 'function' ||
+      typeof obj.HOOK_EVENTS !== 'undefined')
+  );
+}

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -495,10 +495,16 @@ function createWrappedQuery(originalQuery: QueryFn): QueryFn {
       tags: { integration: 'claude_agent_sdk' },
     });
 
-    const originalGen = originalQuery({
-      ...params,
-      options: wrappedOptions as QueryParams['options'],
-    });
+    let originalGen: ReturnType<QueryFn>;
+    try {
+      originalGen = originalQuery({
+        ...params,
+        options: wrappedOptions as QueryParams['options'],
+      });
+    } catch (err) {
+      tracer.endSpan(span);
+      throw err;
+    }
 
     async function* tracedGenerator(): AsyncGenerator<SDKMessage, void> {
       let error: Error | null = null;

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -639,6 +639,7 @@ function createWrappedSession(session: SDKSession): SDKSession {
 
     async function* tracedSessionStream(): AsyncGenerator<SDKMessage, void> {
       let error: Error | null = null;
+      let turnEndedInLoop = false;
       try {
         for await (const message of originalGen) {
           const current = pending.peek();
@@ -661,15 +662,17 @@ function createWrappedSession(session: SDKSession): SDKSession {
                 // best-effort
               }
             }
+            turnEndedInLoop = true;
           }
 
           yield message;
+          turnEndedInLoop = false;
         }
       } catch (err) {
         error = err instanceof Error ? err : new Error(String(err));
         throw err;
       } finally {
-        const closed = pending.pop();
+        const closed = turnEndedInLoop ? undefined : pending.pop();
         if (closed) {
           try {
             applyStateToSpan(closed.span, closed.state);

--- a/src/observability/integrations/claudeAgentWrapper.ts
+++ b/src/observability/integrations/claudeAgentWrapper.ts
@@ -502,6 +502,21 @@ function createWrappedQuery(originalQuery: QueryFn): QueryFn {
         options: wrappedOptions as QueryParams['options'],
       });
     } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      try {
+        applyStateToSpan(span, state);
+      } catch {
+        // best-effort
+      }
+      try {
+        span.setError({
+          code: error.name,
+          message: error.message,
+          stack: error.stack,
+        });
+      } catch {
+        // best-effort
+      }
       tracer.endSpan(span);
       throw err;
     }

--- a/src/observability/integrations/wrapper.ts
+++ b/src/observability/integrations/wrapper.ts
@@ -1,6 +1,10 @@
 import type { OpenAI } from 'openai';
 import { wrapOpenAI } from './openaiWrapper';
 import { wrapVercelAI } from './vercelAIWrapper';
+import {
+  wrapClaudeAgentSdk,
+  isClaudeAgentSdkModule,
+} from './claudeAgentWrapper';
 import { init, isInitialized } from '../../init';
 
 // Type for wrapped clients
@@ -111,6 +115,12 @@ export function wrap<T extends object>(client: T): WrappedClient<T> {
     return wrapVercelAI(client) as WrappedClient<T>;
   }
 
+  if (isClaudeAgentSdkModule(client)) {
+    return wrapClaudeAgentSdk(
+      client as Record<string, unknown>
+    ) as WrappedClient<T>;
+  }
+
   // If we reach here, the client type is not supported
   let clientType = 'unknown';
   if (typeof client === 'object' && client !== null) {
@@ -127,11 +137,13 @@ export function wrap<T extends object>(client: T): WrappedClient<T> {
     `Unsupported client type. ze.wrap() currently supports:\n` +
       `- OpenAI clients (from 'openai' package)\n` +
       `- Vercel AI SDK (from 'ai' package)\n` +
+      `- Claude Agent SDK (from '@anthropic-ai/claude-agent-sdk' package)\n` +
       `\n` +
       `Received: ${clientType}\n` +
       `\n` +
       `Make sure you're passing a valid client instance, e.g.:\n` +
       `  const openai = ze.wrap(new OpenAI());\n` +
-      `  const ai = ze.wrap(await import('ai'));`
+      `  const ai = ze.wrap(await import('ai'));\n` +
+      `  const claude = ze.wrap(await import('@anthropic-ai/claude-agent-sdk'));`
   );
 }

--- a/tests/core/claude-agent-wrapper.test.ts
+++ b/tests/core/claude-agent-wrapper.test.ts
@@ -382,6 +382,39 @@ describe('Claude Agent Wrapper', () => {
       expect(doubleWrapped).toBe(wrapped);
     });
 
+    it('should preserve Query methods on the wrapped return object', async () => {
+      const interrupt = vi.fn();
+      const setModel = vi.fn();
+      const accountInfo = vi.fn().mockResolvedValue({ account: 'ok' });
+
+      const fakeQuery = function fakeQuery() {
+        async function* gen() {
+          yield makeResultMessage();
+        }
+
+        const queryLike = gen() as any;
+        queryLike.interrupt = interrupt;
+        queryLike.setModel = setModel;
+        queryLike.accountInfo = accountInfo;
+        return queryLike;
+      };
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      const wrappedQuery = wrapped({ prompt: 'test' }) as any;
+
+      wrappedQuery.interrupt();
+      wrappedQuery.setModel('claude-sonnet-4-6');
+      const info = await wrappedQuery.accountInfo();
+
+      expect(interrupt).toHaveBeenCalledTimes(1);
+      expect(setModel).toHaveBeenCalledWith('claude-sonnet-4-6');
+      expect(info).toEqual({ account: 'ok' });
+
+      for await (const _ of wrappedQuery) {
+        // consume
+      }
+    });
+
     it('should wrap canUseTool and capture permission decisions', async () => {
       const permissionAllow = { behavior: 'allow' };
       const canUseTool = async () => permissionAllow;

--- a/tests/core/claude-agent-wrapper.test.ts
+++ b/tests/core/claude-agent-wrapper.test.ts
@@ -279,6 +279,26 @@ describe('Claude Agent Wrapper', () => {
       expect(span.status).toBe('error');
     });
 
+    it('should apply state and error when original query throws synchronously', async () => {
+      const fakeQuery = function fakeQuery() {
+        throw new Error('missing api key');
+      };
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+
+      expect(() => wrapped({ prompt: 'sync prompt' })).toThrow('missing api key');
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      const span = mockWriter.spans[0];
+      expect(span.status).toBe('error');
+      expect(span.error_code).toBe('Error');
+      expect(span.error_message).toBe('missing api key');
+      expect(span.input_data).toContain('sync prompt');
+      expect(span.output_data).toBe('');
+    });
+
     it('should count stream events', async () => {
       const fakeQuery = createFakeQuery([
         makeStreamEvent(),

--- a/tests/core/claude-agent-wrapper.test.ts
+++ b/tests/core/claude-agent-wrapper.test.ts
@@ -1,0 +1,701 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestTracer } from '../setup';
+import {
+  wrapClaudeAgentQuery,
+  wrapClaudeAgentSdk,
+  isClaudeAgentSdkModule,
+} from '../../src/observability/integrations/claudeAgentWrapper';
+import { init } from '../../src/init';
+import { tracer } from '../../src/observability/Tracer';
+import type { MockSpanWriter } from '../setup';
+
+// ---------------------------------------------------------------------------
+// Fake SDK message factories
+// ---------------------------------------------------------------------------
+
+function makeAssistantMessage(
+  text: string,
+  sessionId = 'claude-session-1',
+  toolUses: Array<{ name: string; id: string }> = []
+) {
+  const content: Array<Record<string, unknown>> = [];
+  for (const tu of toolUses) {
+    content.push({ type: 'tool_use', name: tu.name, id: tu.id });
+  }
+  if (text) {
+    content.push({ type: 'text', text });
+  }
+  return {
+    type: 'assistant' as const,
+    message: { content, model: 'claude-sonnet-4-6' },
+    parent_tool_use_id: null,
+    uuid: 'uuid-asst-1',
+    session_id: sessionId,
+  };
+}
+
+function makeResultMessage(
+  sessionId = 'claude-session-1',
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    type: 'result' as const,
+    subtype: 'success',
+    duration_ms: 1200,
+    duration_api_ms: 1000,
+    is_error: false,
+    num_turns: 1,
+    result: 'Done.',
+    stop_reason: 'end_turn',
+    total_cost_usd: 0.005,
+    usage: { input_tokens: 100, output_tokens: 50 },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: 'uuid-result-1',
+    session_id: sessionId,
+    ...overrides,
+  };
+}
+
+function makeStreamEvent(sessionId = 'claude-session-1') {
+  return {
+    type: 'stream_event' as const,
+    event: { type: 'content_block_delta' },
+    parent_tool_use_id: null,
+    uuid: 'uuid-stream-1',
+    session_id: sessionId,
+  };
+}
+
+function makeRateLimitEvent(
+  status = 'allowed_warning',
+  utilization = 0.85,
+  sessionId = 'claude-session-1'
+) {
+  return {
+    type: 'rate_limit_event' as const,
+    rate_limit_info: {
+      status,
+      rateLimitType: 'five_hour',
+      utilization,
+    },
+    uuid: 'uuid-rl-1',
+    session_id: sessionId,
+  };
+}
+
+function makeSystemInitMessage(sessionId = 'claude-session-1') {
+  return {
+    type: 'system' as const,
+    subtype: 'init',
+    session_id: sessionId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake query function factory
+// ---------------------------------------------------------------------------
+
+function createFakeQuery(messages: Array<Record<string, unknown>>) {
+  return function fakeQuery() {
+    async function* gen() {
+      for (const msg of messages) {
+        yield msg;
+      }
+    }
+    return gen();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake session factory
+// ---------------------------------------------------------------------------
+
+function createFakeSession(
+  sessionId: string,
+  streamMessages: Array<Array<Record<string, unknown>>>
+) {
+  let streamIdx = 0;
+  let closed = false;
+  const sendLog: Array<string | Record<string, unknown>> = [];
+
+  return {
+    get sessionId() {
+      return sessionId;
+    },
+    async send(message: string | Record<string, unknown>) {
+      sendLog.push(message);
+    },
+    stream() {
+      const msgs = streamMessages[streamIdx] || [];
+      streamIdx++;
+      async function* gen() {
+        for (const msg of msgs) {
+          yield msg;
+        }
+      }
+      return gen();
+    },
+    close() {
+      closed = true;
+    },
+    get _closed() {
+      return closed;
+    },
+    _sendLog: sendLog,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Claude Agent Wrapper', () => {
+  let testTracer: ReturnType<typeof createTestTracer>['tracer'];
+  let mockWriter: MockSpanWriter;
+
+  beforeEach(() => {
+    const t = createTestTracer();
+    testTracer = t.tracer;
+    mockWriter = t.mockWriter;
+
+    // Monkey-patch the singleton tracer used by the wrapper
+    (tracer as any)._writer = mockWriter;
+    (tracer as any)._shuttingDown = false;
+    (tracer as any)._buffer = [];
+    (tracer as any)._traceBuckets = {};
+    (tracer as any)._activeTraceCounts = {};
+    (tracer as any)._traceTags = {};
+    (tracer as any)._sessionTags = {};
+    (tracer as any)._activeSessionCounts = {};
+    (tracer as any)._traceRedactionContexts = {};
+  });
+
+  afterEach(async () => {
+    await tracer.flush();
+    mockWriter.clear();
+  });
+
+  // -----------------------------------------------------------------------
+  // Module shape detection
+  // -----------------------------------------------------------------------
+
+  describe('isClaudeAgentSdkModule', () => {
+    it('should detect a module with query + session helpers', () => {
+      const mod = {
+        query: () => {},
+        unstable_v2_createSession: () => {},
+        listSessions: () => {},
+      };
+      expect(isClaudeAgentSdkModule(mod)).toBe(true);
+    });
+
+    it('should detect a module with query + HOOK_EVENTS', () => {
+      const mod = {
+        query: () => {},
+        HOOK_EVENTS: ['PreToolUse'],
+      };
+      expect(isClaudeAgentSdkModule(mod)).toBe(true);
+    });
+
+    it('should reject an OpenAI client', () => {
+      const client = {
+        chat: { completions: { create: () => {} } },
+        embeddings: { create: () => {} },
+      };
+      expect(isClaudeAgentSdkModule(client)).toBe(false);
+    });
+
+    it('should reject Vercel AI module', () => {
+      const mod = { generateText: () => {}, streamText: () => {} };
+      expect(isClaudeAgentSdkModule(mod)).toBe(false);
+    });
+
+    it('should reject null/undefined', () => {
+      expect(isClaudeAgentSdkModule(null)).toBe(false);
+      expect(isClaudeAgentSdkModule(undefined)).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // wrapClaudeAgentQuery – basic query tracing
+  // -----------------------------------------------------------------------
+
+  describe('wrapClaudeAgentQuery', () => {
+    it('should produce a span with result metadata on successful query', async () => {
+      const fakeQuery = createFakeQuery([
+        makeAssistantMessage('Hello world!'),
+        makeResultMessage(),
+      ]);
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+
+      const messages: unknown[] = [];
+      for await (const msg of wrapped({ prompt: 'Hi there' })) {
+        messages.push(msg);
+      }
+
+      await tracer.flush();
+
+      expect(messages).toHaveLength(2);
+      expect(mockWriter.spans).toHaveLength(1);
+
+      const span = mockWriter.spans[0];
+      expect(span.name).toBe('claude_agent.query');
+      expect(span.attributes.integration).toBe('claude_agent_sdk');
+      expect(span.attributes.kind).toBe('agent');
+      expect(span.attributes.claude_session_id).toBe('claude-session-1');
+      expect(span.session_id).toBe('claude-session-1');
+      expect(span.attributes.total_cost_usd).toBe(0.005);
+      expect(span.attributes.num_turns).toBe(1);
+      expect(span.tags.integration).toBe('claude_agent_sdk');
+      expect(span.input_data).toContain('Hi there');
+      expect(span.output_data).toContain('Hello world!');
+    });
+
+    it('should record error and still end span on query failure', async () => {
+      const fakeQuery = function fakeQuery() {
+        async function* gen() {
+          yield makeAssistantMessage('partial');
+          throw new Error('connection lost');
+        }
+        return gen();
+      };
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+
+      await expect(async () => {
+        for await (const _ of wrapped({ prompt: 'test' })) {
+          // consume
+        }
+      }).rejects.toThrow('connection lost');
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      const span = mockWriter.spans[0];
+      expect(span.error_code).toBe('Error');
+      expect(span.error_message).toBe('connection lost');
+      expect(span.status).toBe('error');
+    });
+
+    it('should count stream events', async () => {
+      const fakeQuery = createFakeQuery([
+        makeStreamEvent(),
+        makeStreamEvent(),
+        makeStreamEvent(),
+        makeAssistantMessage('final'),
+        makeResultMessage(),
+      ]);
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      for await (const _ of wrapped({ prompt: 'test' })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].attributes.stream_event_count).toBe(3);
+    });
+
+    it('should capture tool use blocks', async () => {
+      const fakeQuery = createFakeQuery([
+        makeAssistantMessage('Reading file', 'cs1', [
+          { name: 'Read', id: 'tu1' },
+        ]),
+        makeResultMessage('cs1'),
+      ]);
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      for await (const _ of wrapped({ prompt: 'test' })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans[0].attributes.tool_uses).toEqual([
+        { name: 'Read', id: 'tu1' },
+      ]);
+    });
+
+    it('should capture rate limit events', async () => {
+      const fakeQuery = createFakeQuery([
+        makeRateLimitEvent('allowed_warning', 0.85),
+        makeResultMessage(),
+      ]);
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      for await (const _ of wrapped({ prompt: 'test' })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans[0].attributes.rate_limit_events).toHaveLength(1);
+      expect(
+        mockWriter.spans[0].attributes.rate_limit_events[0].status
+      ).toBe('allowed_warning');
+    });
+
+    it('should end span on early generator close', async () => {
+      const fakeQuery = createFakeQuery([
+        makeAssistantMessage('Hello'),
+        makeResultMessage(),
+      ]);
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      const gen = wrapped({ prompt: 'test' });
+      await gen.next();
+      await gen.return(undefined as any);
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].end_time).toBeDefined();
+    });
+
+    it('should be idempotent (no double-wrap)', () => {
+      const fakeQuery = createFakeQuery([]);
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      const doubleWrapped = wrapClaudeAgentQuery(wrapped);
+      expect(doubleWrapped).toBe(wrapped);
+    });
+
+    it('should wrap canUseTool and capture permission decisions', async () => {
+      const permissionAllow = { behavior: 'allow' };
+      const canUseTool = async () => permissionAllow;
+
+      const fakeQuery = function fakeQuery(params: any) {
+        async function* gen() {
+          if (params.options?.canUseTool) {
+            await params.options.canUseTool('Bash', { command: 'ls' }, {
+              toolUseID: 'tu1',
+              agentID: 'a1',
+            });
+          }
+          yield makeResultMessage();
+        }
+        return gen();
+      };
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      for await (const _ of wrapped({
+        prompt: 'test',
+        options: { canUseTool },
+      })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(
+        mockWriter.spans[0].attributes.permission_decisions
+      ).toHaveLength(1);
+      expect(
+        mockWriter.spans[0].attributes.permission_decisions[0].toolName
+      ).toBe('Bash');
+      expect(
+        mockWriter.spans[0].attributes.permission_decisions[0].behavior
+      ).toBe('allow');
+    });
+
+    it('should wrap hooks and capture hook events', async () => {
+      const hookCb = async (input: any) => ({
+        hookSpecificOutput: { hookEventName: 'PreToolUse' },
+      });
+
+      const fakeQuery = function fakeQuery(params: any) {
+        async function* gen() {
+          const hooks = params.options?.hooks;
+          if (hooks?.PreToolUse) {
+            for (const matcher of hooks.PreToolUse) {
+              for (const hook of matcher.hooks) {
+                await hook(
+                  { hook_event_name: 'PreToolUse', tool_name: 'Bash' },
+                  'tu1',
+                  {}
+                );
+              }
+            }
+          }
+          yield makeResultMessage();
+        }
+        return gen();
+      };
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      for await (const _ of wrapped({
+        prompt: 'test',
+        options: {
+          hooks: {
+            PreToolUse: [{ hooks: [hookCb] }],
+          },
+        },
+      })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans[0].attributes.hook_events).toHaveLength(1);
+      expect(
+        mockWriter.spans[0].attributes.hook_events[0].eventName
+      ).toBe('PreToolUse');
+      expect(
+        mockWriter.spans[0].attributes.hook_events[0].toolName
+      ).toBe('Bash');
+    });
+
+    it('should use result text as output when no assistant text was accumulated', async () => {
+      const fakeQuery = createFakeQuery([
+        makeResultMessage('cs1', { result: 'Final answer from result.' }),
+      ]);
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      for await (const _ of wrapped({ prompt: 'test' })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans[0].output_data).toContain(
+        'Final answer from result.'
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // wrapClaudeAgentSdk – module-level wrapping
+  // -----------------------------------------------------------------------
+
+  describe('wrapClaudeAgentSdk', () => {
+    it('should wrap the query function on the module', async () => {
+      const mod = {
+        query: createFakeQuery([
+          makeAssistantMessage('Hi'),
+          makeResultMessage(),
+        ]),
+        HOOK_EVENTS: ['PreToolUse'],
+      };
+
+      const wrapped = wrapClaudeAgentSdk(mod);
+
+      expect(wrapped.__zeroeval_wrapped).toBe(true);
+      expect(wrapped.query).not.toBe(mod.query);
+      expect(wrapped.HOOK_EVENTS).toBe(mod.HOOK_EVENTS);
+
+      for await (const _ of (wrapped.query as any)({ prompt: 'Hi' })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].name).toBe('claude_agent.query');
+    });
+
+    it('should be idempotent', () => {
+      const mod = { query: createFakeQuery([]) };
+      const wrapped = wrapClaudeAgentSdk(mod);
+      const doubleWrapped = wrapClaudeAgentSdk(wrapped as any);
+      expect(doubleWrapped).toBe(wrapped);
+    });
+
+    it('should wrap unstable_v2_createSession when present', async () => {
+      const fakeSession = createFakeSession('sess-1', [
+        [makeAssistantMessage('Hi', 'sess-1'), makeResultMessage('sess-1')],
+      ]);
+
+      const mod = {
+        query: createFakeQuery([]),
+        unstable_v2_createSession: () => fakeSession,
+      };
+
+      const wrapped = wrapClaudeAgentSdk(mod);
+      const session = (wrapped.unstable_v2_createSession as any)({
+        model: 'claude-sonnet-4-6',
+      });
+
+      await session.send('Hello');
+      for await (const _ of session.stream()) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].name).toBe('claude_agent.turn');
+      expect(mockWriter.spans[0].attributes.claude_session_id).toBe('sess-1');
+    });
+
+    it('should wrap unstable_v2_resumeSession when present', async () => {
+      const fakeSession = createFakeSession('sess-2', [
+        [makeAssistantMessage('Resumed', 'sess-2'), makeResultMessage('sess-2')],
+      ]);
+
+      const mod = {
+        query: createFakeQuery([]),
+        unstable_v2_resumeSession: () => fakeSession,
+      };
+
+      const wrapped = wrapClaudeAgentSdk(mod);
+      const session = (wrapped.unstable_v2_resumeSession as any)('sess-2', {
+        model: 'claude-sonnet-4-6',
+      });
+
+      await session.send('Continue');
+      for await (const _ of session.stream()) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].name).toBe('claude_agent.turn');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Session tracing
+  // -----------------------------------------------------------------------
+
+  describe('session tracing', () => {
+    it('should create separate traces for sequential turns', async () => {
+      const fakeSession = createFakeSession('sess-1', [
+        [makeAssistantMessage('Turn 1 reply', 'sess-1'), makeResultMessage('sess-1')],
+        [
+          makeAssistantMessage('Turn 2 reply', 'sess-1'),
+          makeResultMessage('sess-1', { num_turns: 2 }),
+        ],
+      ]);
+
+      const mod = {
+        query: createFakeQuery([]),
+        unstable_v2_createSession: () => fakeSession,
+      };
+
+      const wrapped = wrapClaudeAgentSdk(mod);
+      const session = (wrapped.unstable_v2_createSession as any)({
+        model: 'claude-sonnet-4-6',
+      });
+
+      await session.send('Turn 1');
+      for await (const _ of session.stream()) {
+        // consume
+      }
+
+      await session.send('Turn 2');
+      for await (const _ of session.stream()) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(2);
+      expect(mockWriter.spans[0].name).toBe('claude_agent.turn');
+      expect(mockWriter.spans[1].name).toBe('claude_agent.turn');
+      expect(mockWriter.spans[0].session_id).toBe('sess-1');
+      expect(mockWriter.spans[1].session_id).toBe('sess-1');
+      expect(mockWriter.spans[0].trace_id).not.toBe(
+        mockWriter.spans[1].trace_id
+      );
+    });
+
+    it('should mark pending spans as interrupted on session close', async () => {
+      const fakeSession = createFakeSession('sess-1', []);
+
+      const mod = {
+        query: createFakeQuery([]),
+        unstable_v2_createSession: () => fakeSession,
+      };
+
+      const wrapped = wrapClaudeAgentSdk(mod);
+      const session = (wrapped.unstable_v2_createSession as any)({
+        model: 'claude-sonnet-4-6',
+      });
+
+      await session.send('Hello');
+      session.close();
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].attributes.interrupted).toBe(true);
+    });
+
+    it('should handle stream errors for session turns', async () => {
+      const fakeSession = {
+        get sessionId() {
+          return 'sess-err';
+        },
+        async send() {},
+        stream() {
+          async function* gen() {
+            yield makeAssistantMessage('partial', 'sess-err');
+            throw new Error('stream broke');
+          }
+          return gen();
+        },
+        close() {},
+      };
+
+      const mod = {
+        query: createFakeQuery([]),
+        unstable_v2_createSession: () => fakeSession,
+      };
+
+      const wrapped = wrapClaudeAgentSdk(mod);
+      const session = (wrapped.unstable_v2_createSession as any)({
+        model: 'claude-sonnet-4-6',
+      });
+
+      await session.send('Hello');
+      await expect(async () => {
+        for await (const _ of session.stream()) {
+          // consume
+        }
+      }).rejects.toThrow('stream broke');
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].status).toBe('error');
+      expect(mockWriter.spans[0].error_message).toBe('stream broke');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Session ID late-binding
+  // -----------------------------------------------------------------------
+
+  describe('session ID late-binding', () => {
+    it('should not overwrite session_id when no Claude session emitted', async () => {
+      const fakeQuery = createFakeQuery([
+        {
+          type: 'result',
+          subtype: 'success',
+          duration_ms: 100,
+          is_error: false,
+          num_turns: 1,
+          result: 'ok',
+          total_cost_usd: 0.001,
+          usage: {},
+          uuid: 'u1',
+          session_id: '',
+        },
+      ]);
+
+      const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+      for await (const _ of wrapped({ prompt: 'test' })) {
+        // consume
+      }
+
+      await tracer.flush();
+
+      expect(mockWriter.spans).toHaveLength(1);
+      expect(mockWriter.spans[0].attributes.claude_session_id).toBeUndefined();
+    });
+  });
+});

--- a/tests/core/wrapper-redaction.test.ts
+++ b/tests/core/wrapper-redaction.test.ts
@@ -5,6 +5,7 @@ import { tracer } from '../../src/observability/Tracer';
 import { ZeroEvalCallbackHandler } from '../../src/observability/integrations/langchain/ZeroEvalCallbackHandler';
 import { wrapOpenAI } from '../../src/observability/integrations/openaiWrapper';
 import { wrapVercelAI } from '../../src/observability/integrations/vercelAIWrapper';
+import { wrapClaudeAgentQuery } from '../../src/observability/integrations/claudeAgentWrapper';
 import { MockSpanWriter } from '../setup';
 
 describe('wrapper redaction', () => {
@@ -186,6 +187,51 @@ describe('wrapper redaction', () => {
     expect(mockWriter.spans).toHaveLength(1);
     expect(mockWriter.spans[0].input_data).toContain('[REDACTED_EMAIL_A]');
     expect(mockWriter.spans[0].input_data).not.toContain('[REDACTED_SECRET');
+  });
+
+  it('should redact Claude Agent wrapper prompt and output', async () => {
+    const fakeQuery = function fakeQuery() {
+      async function* gen() {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: 'Reach me at bob@example.com or +1 (415) 555-1212' },
+            ],
+          },
+          parent_tool_use_id: null,
+          uuid: 'u1',
+          session_id: 'cs1',
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          duration_ms: 100,
+          is_error: false,
+          num_turns: 1,
+          result: 'done',
+          total_cost_usd: 0.001,
+          usage: {},
+          uuid: 'u2',
+          session_id: 'cs1',
+        };
+      }
+      return gen();
+    };
+
+    const wrapped = wrapClaudeAgentQuery(fakeQuery as any);
+    for await (const _ of wrapped({
+      prompt: 'Email bob@example.com about the JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.foo.bar',
+    })) {
+      // consume
+    }
+    await tracer.flush();
+
+    expect(mockWriter.spans).toHaveLength(1);
+    const span = mockWriter.spans[0];
+    expect(span.input_data).not.toContain('bob@example.com');
+    expect(span.output_data).toContain('[REDACTED_EMAIL_A]');
+    expect(span.output_data).toContain('[REDACTED_PHONE_A]');
   });
 
   it('should fall back to an empty object for falsy Vercel generateObject results', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new integration that wraps async generators and session flows, which can affect tracing behavior and error handling in production. Also introduces a new optional peer dependency and expands the dependency graph via lockfile updates.
> 
> **Overview**
> Adds a **Claude Agent SDK integration** with new `wrapClaudeAgentSdk`/`wrapClaudeAgentQuery` APIs and auto-detection in `ze.wrap()`, emitting spans for `query` and `unstable_v2_*Session` turns while capturing result metadata, tool use, hooks, rate-limit events, and errors.
> 
> Updates the public exports and docs to include Claude usage, adds a new runnable example, and expands test coverage (including redaction) for the new wrapper. Bumps package version to `0.1.19` and adds `@anthropic-ai/claude-agent-sdk` as an optional peer dependency (plus lockfile dependency updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 543e20efc12497a3759d443fa053d7bbfda4ab92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->